### PR TITLE
A misspelled blockHelperMissing ref is causing "undefined" exception

### DIFF
--- a/lib/handlebars/runtime.js
+++ b/lib/handlebars/runtime.js
@@ -120,7 +120,7 @@ Handlebars.Runtime.prototype = {
     if(!functionType && params.length) {
       params = params.slice(0);
       params.unshift(data || mustache.id.original);
-      data = this.context.helpers.helperMissing;
+      data = this.context.helpers.blockHelperMissing;
       functionType = true;
     }
 


### PR DESCRIPTION
I believe this is just a typo.

Alex
