### PR TITLE
improved "with" and "each" helpers to support function as argument

### DIFF
--- a/lib/handlebars/base.js
+++ b/lib/handlebars/base.js
@@ -72,7 +72,8 @@ Handlebars.registerHelper('blockHelperMissing', function(context, fn, inverse) {
   return fn(context);
 });
 
-Handlebars.registerHelper('each', function(context, fn, inverse) {
+Handlebars.registerHelper('each', function(ctx, fn, inverse) {
+  var context = typeof ctx == "function" ? ctx.call(this) : ctx;
   var ret = "";
 
   if(context && context.length > 0) {
@@ -98,7 +99,8 @@ Handlebars.registerHelper('unless', function(context, fn, inverse) {
   Handlebars.helpers['if'].call(this, context, inverse, fn);
 });
 
-Handlebars.registerHelper('with', function(context, fn) {
+Handlebars.registerHelper('with', function(ctx, fn) {
+  var context = typeof ctx == "function" ? ctx.call(this) : ctx;
   return fn(context);
 });
 

--- a/spec/qunit_spec.js
+++ b/spec/qunit_spec.js
@@ -490,10 +490,17 @@ test("if a context is not found, helperMissing is used", function() {
 
 module("built-in helpers");
 
-test("with", function() {
+test("with non-function argument", function() {
   var string = "{{#with person}}{{first}} {{last}}{{/with}}";
 
   shouldCompileTo(string, {person: {first: "Alan", last: "Johnson"}}, "Alan Johnson");
+});
+
+test("with function argument", function() {
+  var string = "{{#with person}}{{first}} {{last}}{{/with}}";
+
+  shouldCompileTo(string, {person: function() {return {first: this.firsName, last: this.lastName};},
+                  firsName: "Alan", lastName: "Johnson"}, "Alan Johnson");
 });
 
 test("if with non-function argument", function() {
@@ -518,4 +525,23 @@ test("if with function argument", function() {
                   "if with function does not show the contents when returns false");
   shouldCompileTo(string, {goodbye: function() {return this.foo}, world: "world"}, "cruel world!",
                   "if with function does not show the contents when returns undefined");
+});
+
+test("each with non-function argument", function() {
+  var string   = "{{#each goodbyes}}{{text}}! {{/each}}cruel {{world}}!"
+  var hash     = {goodbyes: [{text: "goodbye"}, {text: "Goodbye"}, {text: "GOODBYE"}], world: "world"};
+  shouldCompileTo(string, hash, "goodbye! Goodbye! GOODBYE! cruel world!",
+                  "each with array argument iterates over the contents when not empty");
+  shouldCompileTo(string, {goodbyes: [], world: "world"}, "cruel world!",
+                  "each with array argument ignores the contents when empty");
+});
+
+test("each with function argument", function() {
+  var string   = "{{#each goodbyes}}{{text}}! {{/each}}cruel {{world}}!"
+  var hash     = {goodbyes: function() {return this.texts;},
+                  texts: [{text: "goodbye"}, {text: "Goodbye"}, {text: "GOODBYE"}], world: "world"};
+  shouldCompileTo(string, hash, "goodbye! Goodbye! GOODBYE! cruel world!",
+                  "each with function argument returning array iterates over the contents when not empty");
+  shouldCompileTo(string, {goodbyes: [], world: "world"}, "cruel world!",
+                  "each with function argument returning array ignores the contents when empty");
 });


### PR DESCRIPTION
As you accepted my improved "if" helper then I am sending patch for "with" and "each" helpers as well to support function as argument.

{{#each methodName}} is useful if you pass object to template which has methodName method which returns array. As if you will use just {{#method_name}} then Handlebars will consider methodName as helper and will insert returned result directly into output and will not iterate over the array.

{{#with methodName}} is useful when object has methodName method which returns object and in inner block you want to access properties of returned object. In this case {{#methodName}} as well will work differently and will insert returned result into output.
