### PR TITLE
Fix to make Handlebars work in IE 7

### DIFF
--- a/lib/handlebars/utils.js
+++ b/lib/handlebars/utils.js
@@ -16,7 +16,7 @@ Handlebars.SafeString.prototype.toString = function() {
 (function() {
   var escape = {
     "<": "&lt;",
-    ">": "&gt;",
+    ">": "&gt;"
   };
 
   var badChars = /&(?!\w+;)|[<>]/g;


### PR DESCRIPTION
IE 7 hates trailing commas, which was causing my templates to fail rendering in IE 7. I'm getting the feeling that you guys don't test Handlebars in IE much... ;)

(I wouldn't either if work didn't make me support IE...)
