### PR TITLE
Checks to see if jison is installed before attempting to run it in Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,8 +2,12 @@ require "rubygems"
 require "bundler/setup"
 
 file "lib/handlebars/parser.js" => ["src/handlebars.yy","src/handlebars.l"] do
-  system "jison src/handlebars.yy src/handlebars.l"
-  sh "mv handlebars.js lib/handlebars/parser.js"
+  if ENV['PATH'].split(':').any? {|folder| File.exists?(folder+'/jison')}
+    system "jison src/handlebars.yy src/handlebars.l"
+    sh "mv handlebars.js lib/handlebars/parser.js"
+  else
+    puts "Jison is not installed. Try running `npm install jison`."
+  end
 end
 
 task :compile => "lib/handlebars/parser.js"


### PR DESCRIPTION
This probably isn't the best long-term solution, but I ran into several issues attempting to build the project without having Jison installed and think I could have saved a bit of time if this check and message had been in the Rakefile.
