### PR TITLE
The "if" block helper shouldn't treat empty arrays as truthy

### DIFF
--- a/lib/handlebars/base.js
+++ b/lib/handlebars/base.js
@@ -86,7 +86,7 @@ Handlebars.registerHelper('each', function(context, fn, inverse) {
 });
 
 Handlebars.registerHelper('if', function(context, fn, inverse) {
-  if(!context || context == []) {
+  if(!context || Handlebars.Utils.isEmpty(context)) {
     return inverse(this);
   } else {
     return fn(this);

--- a/spec/qunit_spec.js
+++ b/spec/qunit_spec.js
@@ -502,6 +502,10 @@ test("if", function() {
                   "if with boolean argument does not show the contents when false");
   shouldCompileTo(string, {world: "world"}, "cruel world!",
                   "if with undefined does not show the contents");
+  shouldCompileTo(string, {goodbye: ['foo'], world: "world"}, "GOODBYE cruel world!",
+                  "if with non-empty array shows the contents");
+  shouldCompileTo(string, {goodbye: [], world: "world"}, "cruel world!",
+                  "if with empty array does not show the contents");
 });
 
 test("each", function() {


### PR DESCRIPTION
Given the data `{foo: []}`, the following template previously considered foo to be truthy when it shouldn't have:

```
{{#if foo}}
  You should not see me!
{{else}}
  You should see me!
{{/if}}
```
