### PR TITLE
Add ", ', and ` to the list of chars that need HTML escaping.

### DIFF
--- a/lib/handlebars/utils.js
+++ b/lib/handlebars/utils.js
@@ -19,11 +19,11 @@ Handlebars.SafeString.prototype.toString = function() {
     ">": "&gt;",
     '"': "&quot;",
     "'": "&#x27;",
-    "/": "&#x2F;"
+    "`": "&#x60;"
   };
 
-  var badChars = /&(?!\w+;)|[<>"'\/]/g;
-  var possible = /[&<>"'\/]/;
+  var badChars = /&(?!\w+;)|[<>"'`]/g;
+  var possible = /[&<>"'`]/;
 
   var escapeChar = function(chr) {
     return escape[chr] || "&amp;"

--- a/spec/qunit_spec.js
+++ b/spec/qunit_spec.js
@@ -90,7 +90,7 @@ test("escaping expressions", function() {
  shouldCompileTo("{{&awesome}}", {awesome: "&\"\\<>"}, '&\"\\<>',
         "expressions with {{& handlebars aren't escaped");
 
- shouldCompileTo("{{awesome}}", {awesome: "&\"'/\\<>"}, '&amp;&quot;&#x27;&#x2F;\\&lt;&gt;',
+ shouldCompileTo("{{awesome}}", {awesome: "&\"'`\\<>"}, '&amp;&quot;&#x27;&#x60;\\&lt;&gt;',
         "by default expressions should be escaped");
 
 });
@@ -397,7 +397,7 @@ test("basic partials", function() {
   var string = "Dudes: {{#dudes}}{{> dude}}{{/dudes}}";
   var partial = "{{name}} ({{url}}) ";
   var hash = {dudes: [{name: "Yehuda", url: "http://yehuda"}, {name: "Alan", url: "http://alan"}]};
-  shouldCompileTo(string, [hash, {}, {dude: partial}], "Dudes: Yehuda (http:&#x2F;&#x2F;yehuda) Alan (http:&#x2F;&#x2F;alan) ",
+  shouldCompileTo(string, [hash, {}, {dude: partial}], "Dudes: Yehuda (http://yehuda) Alan (http://alan) ",
                   "Basic partials output based on current context.");
 });
 
@@ -405,7 +405,7 @@ test("partials with context", function() {
   var string = "Dudes: {{>dude dudes}}";
   var partial = "{{#this}}{{name}} ({{url}}) {{/this}}";
   var hash = {dudes: [{name: "Yehuda", url: "http://yehuda"}, {name: "Alan", url: "http://alan"}]};
-  shouldCompileTo(string, [hash, {}, {dude: partial}], "Dudes: Yehuda (http:&#x2F;&#x2F;yehuda) Alan (http:&#x2F;&#x2F;alan) ",
+  shouldCompileTo(string, [hash, {}, {dude: partial}], "Dudes: Yehuda (http://yehuda) Alan (http://alan) ",
                   "Partials can be passed a context");
 });
 
@@ -414,7 +414,7 @@ test("partial in a partial", function() {
   var dude = "{{name}} {{> url}} ";
   var url = "<a href='{{url}}'>{{url}}</a>";
   var hash = {dudes: [{name: "Yehuda", url: "http://yehuda"}, {name: "Alan", url: "http://alan"}]};
-  shouldCompileTo(string, [hash, {}, {dude: dude, url: url}], "Dudes: Yehuda <a href='http:&#x2F;&#x2F;yehuda'>http:&#x2F;&#x2F;yehuda</a> Alan <a href='http:&#x2F;&#x2F;alan'>http:&#x2F;&#x2F;alan</a> ", "Partials are rendered inside of other partials");
+  shouldCompileTo(string, [hash, {}, {dude: dude, url: url}], "Dudes: Yehuda <a href='http://yehuda'>http://yehuda</a> Alan <a href='http://alan'>http://alan</a> ", "Partials are rendered inside of other partials");
 });
 
 test("rendering undefined partial throws an exception", function() {


### PR DESCRIPTION
Previously, only `<` and `>` were escaped. This meant that any Handlebars
template that used user input in an HTML attribute value was wide open
to a trivial XSS exploit. Note that unquoted attribute values are still
open to attack, but this set of characters at least brings Handlebars in
line with other Mustache implementations and other template languages.

See the OWASP XSS prevention cheat sheet (rule #1) for the rationale
behind escaping these characters:

https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
