### PR TITLE
Allow ids to contain hyphens. Fixes #36.

### DIFF
--- a/lib/handlebars/vm.js
+++ b/lib/handlebars/vm.js
@@ -273,7 +273,7 @@ Handlebars.JavaScriptCompiler = function() {};
     // PUBLIC API: You can override these methods in a subclass to provide
     // alternative compiled forms for name lookup and buffering semantics
     nameLookup: function(parent, name, type) {
-      if(JavaScriptCompiler.RESERVED_WORDS[name]) {
+      if(JavaScriptCompiler.RESERVED_WORDS[name] || name.indexOf('-') !== -1) {
         return parent + "['" + name + "']";
       } else {
         return parent + "." + name;

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -113,6 +113,10 @@ describe "Parser" do
     ast_for("{{this/foo}}").should == program { mustache id("foo") }
   end
 
+  it "parses mustaches with - in a path" do
+    ast_for("{{foo-bar}}").should == program { mustache id("foo-bar") }
+  end
+
   it "parses mustaches with parameters" do
     ast_for("{{foo bar}}").should == program { mustache id("foo"), [id("bar")] }
   end

--- a/spec/qunit_spec.js
+++ b/spec/qunit_spec.js
@@ -106,6 +106,10 @@ test("functions with context argument", function() {
       "Frank", "functions are called with context arguments");
 });
 
+test("paths with hyphens", function() {
+  shouldCompileTo("{{foo-bar}}", {"foo-bar": "baz"}, "baz", "Paths can contain hyphens (-)");
+});
+
 test("nested paths", function() {
   shouldCompileTo("Goodbye {{alan/expression}} world!", {alan: {expression: "beautiful"}},
                   "Goodbye beautiful world!", "Nested paths access nested objects");

--- a/src/handlebars.l
+++ b/src/handlebars.l
@@ -24,7 +24,7 @@
 <mu>"}}}"                    { this.begin("INITIAL"); return 'CLOSE'; }
 <mu>"}}"                     { this.begin("INITIAL"); return 'CLOSE'; }
 <mu>'"'("\\"["]|[^"])*'"'    { yytext = yytext.substr(1,yyleng-2).replace(/\\"/g,'"'); return 'STRING'; }
-<mu>[a-zA-Z0-9_]+/[=} /.]    { return 'ID'; }
+<mu>[a-zA-Z0-9_-]+/[=} /.]   { return 'ID'; }
 <mu>.                        { return 'INVALID'; }
 
 <INITIAL,mu><<EOF>>          { return 'EOF'; }


### PR DESCRIPTION
Previously, a mustache like `{{foo-bar}}` would generate a
parse error, which was a departure from the behavior of
other Mustache implementations.
