### PR TITLE
missing semicolon prevents minification

### DIFF
--- a/lib/handlebars/utils.js
+++ b/lib/handlebars/utils.js
@@ -20,7 +20,7 @@ Handlebars.SafeString.prototype.toString = function() {
   };
 
   var badChars = /&(?!\w+;)|[<>]/g;
-  var possible = /[&<>]/
+  var possible = /[&<>]/;
 
   var escapeChar = function(chr) {
     return escape[chr] || "&amp;"


### PR DESCRIPTION
not too much to explain here. the javascript minifier i use is breaking due to this missing semicolon.
