### PR TITLE
allow number indexes in paths for array access

### DIFF
--- a/lib/handlebars/compiler.js
+++ b/lib/handlebars/compiler.js
@@ -290,6 +290,8 @@ Handlebars.JavaScriptCompiler = function() {};
     nameLookup: function(parent, name, type) {
       if(JavaScriptCompiler.RESERVED_WORDS[name] || name.indexOf('-') !== -1) {
         return parent + "['" + name + "']";
+      } else if (/^[0-9]+$/.test(name)) {
+        return parent + "[" + name + "]";
       } else {
         return parent + "." + name;
       }


### PR DESCRIPTION
Hope I'm not spamming.  This would make it easy to access specific array indexes like:

{{people/0/name}}

This is a nice feature in Django templates that occasionally comes in handy.
