### PR TITLE
inline partials: ability to create partials as part of a block for later re-use

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -166,6 +166,43 @@ example:
     //   <li><a href="/people/2">Yehuda</a></li>
     // </ul>
 
+You can also set a context for a partial after the partial's name, so in the above example, if we change:
+
+    source = "<ul><li>{{> link person }}</li></ul>";
+    Handlebars.compile(source)({"person":{"name":"Jake", "id":3}});
+
+    // Should render:
+    // <ul>
+    //   <li><a href="/people/3">Jake</a></li>
+    // </ul>
+
+
+#### Inline Partials
+
+In Handlebars, you can also declare a partial in its first use instead of registering it separately.  Inline partials are declared like blocks except they are prefixed with '>>' so:
+
+    var source = "<p>Welcome,{{#>>link}}<a href="/people/{{id}}">{{name}}</a>{{/>>link}} </p>"
+            +"Your friends: <ul>{{#friends}}<li>{{> link}}</li>{{/friends}}</ul>";
+    var template = Handlebars.compile(source);
+    var data = { 
+        "name":"Meghan", "id": 4,
+        "friends": [
+                   { "name": "Alan", "id": 1 },
+                   { "name": "Yehuda", "id": 2 }
+                   ]
+        };
+
+    template(data);
+
+    // Should render:
+    // <p>Welcome,<a href="/people/4">Meghan</a</p>
+    // Your friends:
+    // <ul>
+    //   <li><a href="/people/1">Alan</a></li>
+    //   <li><a href="/people/2">Yehuda</a></li>
+    // </ul>
+
+
 Precompiling Templates
 ----------------------
 

--- a/lib/handlebars/ast.js
+++ b/lib/handlebars/ast.js
@@ -34,6 +34,20 @@ var Handlebars = require("handlebars");
     }
   };
 
+  Handlebars.AST.InlinePartialNode = function(mustache, program, close) {
+    verifyMatch(mustache.id, close);
+    var environment = new Handlebars.Compiler().compile(program);
+    var compiled_partial = new Handlebars.JavaScriptCompiler().compile(environment);
+    Handlebars.registerPartial(mustache.id.original, compiled_partial);
+
+    this.type = "partial";
+    this.id = mustache.id;
+    if (mustache.params.length) {
+        this.context = mustache.params[0];
+    }
+
+  };
+
   Handlebars.AST.BlockNode = function(mustache, program, close) {
     verifyMatch(mustache.id, close);
     this.type = "block";

--- a/spec/qunit_spec.js
+++ b/spec/qunit_spec.js
@@ -425,6 +425,12 @@ test("GH-14: a partial preceding a selector", function() {
    shouldCompileTo(string, [hash, {}, {dude:dude}], "Dudes: Jeepers Creepers", "Regular selectors can follow a partial");
 });
 
+test("inline partials", function() {
+  var string = "Yo! {{#>>dude the_dude}}{{name}}{{/>>dude}}, Meet friends:{{#dudes}} {{>dude}}{{/dudes}}";
+  var hash = {the_dude:{name:"Jeff Lebowski"},dudes:[{name:"Bert"},{name:"Ernie"},{name:"BigBird"}]}
+  shouldCompileTo(string, hash, "Yo! Jeff Lebowski, Meet friends: Bert Ernie BigBird", "");
+});
+
 module("String literal parameters");
 
 test("simple literals work", function() {

--- a/src/handlebars.l
+++ b/src/handlebars.l
@@ -6,8 +6,10 @@
 [^\x00]*?/("{{")                 { this.begin("mu"); if (yytext) return 'CONTENT'; }
 [^\x00]+                         { return 'CONTENT'; }
 
+<mu>"{{#>>"                  { return 'OPEN_INLINE_PARTIAL'; }
 <mu>"{{>"                    { return 'OPEN_PARTIAL'; }
 <mu>"{{#"                    { return 'OPEN_BLOCK'; }
+<mu>"{{/>>"                  { return 'OPEN_ENDINLINE_PARTIAL'; }
 <mu>"{{/"                    { return 'OPEN_ENDBLOCK'; }
 <mu>"{{^"                    { return 'OPEN_INVERSE'; }
 <mu>"{{"\s*"else"            { return 'OPEN_INVERSE'; }

--- a/src/handlebars.yy
+++ b/src/handlebars.yy
@@ -20,6 +20,7 @@ statements
 statement
   : openInverse program closeBlock { $$ = new yy.InverseNode($1, $2, $3) }
   | openBlock program closeBlock { $$ = new yy.BlockNode($1, $2, $3) }
+  | openInlinePartial program closeInlinePartial { $$ = new yy.InlinePartialNode($1, $2, $3) }
   | mustache { $$ = $1 }
   | partial { $$ = $1 }
   | CONTENT { $$ = new yy.ContentNode($1) }
@@ -30,12 +31,22 @@ openBlock
   : OPEN_BLOCK inMustache CLOSE { $$ = new yy.MustacheNode($2[0], $2[1]) }
   ;
 
+openInlinePartial
+  : OPEN_INLINE_PARTIAL path CLOSE { $$ = new yy.MustacheNode([$2], null) }
+  | OPEN_INLINE_PARTIAL path path CLOSE { $$ = new yy.MustacheNode([$2, $3], null) }
+
+  ;
+
 openInverse
   : OPEN_INVERSE inMustache CLOSE { $$ = new yy.MustacheNode($2[0], $2[1]) }
   ;
 
 closeBlock
   : OPEN_ENDBLOCK path CLOSE { $$ = $2 }
+  ;
+
+closeInlinePartial
+  : OPEN_ENDINLINE_PARTIAL path CLOSE { $$ = $2 }
   ;
 
 mustache


### PR DESCRIPTION
This is a cleaner single-patch against current master and an update to this request:
https://github.com/wycats/handlebars.js/pull/78

which said:
This creates an inline-partial syntax so you can declare a partial the first time it's used without separating it out into a separate string/file. The syntax looks like this:

"Yo! {{#>>dude}} Mr. {{name}}{{/>>dude}}, Meet friends:{{#dudes}} {{>dude}}{{/dudes}}"

The block-like syntax is nice, since the closing tag clearly marks what is being closed (one of the reasons I love mustache/handlebars).

This has some nice advantages:
1. The same file can create a partial, for use elsewhere
2. On client-side, if certain sections are updated, that partial can be called with a new object instead of updating the whole template
3. A partial can be declared within a context, so it's more easily understood when/where it should be used.
