### PR TITLE
The missing semicolon is breaking our code when we minify. 

### DIFF
--- a/lib/handlebars/compiler/compiler.js
+++ b/lib/handlebars/compiler/compiler.js
@@ -521,7 +521,8 @@ Handlebars.JavaScriptCompiler = function() {};
               + " || "
               + this.nameLookup('depth' + this.lastContext, name, 'context');
         }
-
+        
+        toPush += ';';
         this.source.push(toPush);
       } else {
         this.pushStack('depth' + this.lastContext);


### PR DESCRIPTION
Couldn't find any other lines generated without a semicolon, so at least for consistency. 
