### PR TITLE
Add rake to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source "http://rubygems.org"
 
+gem "rake"
 gem "therubyracer", ">= 0.8.0"
 gem "rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ GEM
   remote: http://rubygems.org/
   specs:
     diff-lcs (1.1.2)
+    rake (0.9.2)
     rspec (2.1.0)
       rspec-core (~> 2.1.0)
       rspec-expectations (~> 2.1.0)
@@ -16,5 +17,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  rake
   rspec
   therubyracer (>= 0.8.0)


### PR DESCRIPTION
If you clone a fresh copy of the repository and bundle install, you won't be able to rake spec/compile because rake is missing.

```
➜  handlebars.js git:(master) bundle install && rake spec   
Using diff-lcs (1.1.2) 
Using rspec-core (2.1.0) 
Using rspec-expectations (2.1.0) 
Using rspec-mocks (2.1.0) 
Using rspec (2.1.0) 
Using therubyracer (0.8.0) 
Using bundler (1.0.18) 
Your bundle is complete! Use `bundle show [gemname]` to see where a bundled gem is installed.
/Users/jroes/.rvm/gems/ruby-1.9.2-p180/gems/bundler-1.0.18/lib/bundler/rubygems_integration.rb:143:in `block in replace_gem': rake is not part of the bundle. Add it to Gemfile. (Gem::LoadError)
    from /Users/jroes/.rvm/gems/ruby-1.9.2-p180/bin/rake:18:in `<main>'
```
