### PR TITLE
Added a noEscape option to Handlebars.compile

### DIFF
--- a/lib/handlebars/compiler/compiler.js
+++ b/lib/handlebars/compiler/compiler.js
@@ -220,7 +220,7 @@ Handlebars.JavaScriptCompiler = function() {};
 
       this.opcode('invokeMustache', params.length, mustache.id.original, !!mustache.hash);
 
-      if(mustache.escaped) {
+      if(mustache.escaped && !this.options.noEscape) {
         this.opcode('appendEscaped');
       } else {
         this.opcode('append');


### PR DESCRIPTION
I'm using Handlebars in the creation of a CMS, and nearly all of the content I insert into my templates is HTML. The templates look ugly with {{{ }}} everywhere, so I added a simple option to turn off escaping. Not sure if you'll like this idea but I thought I'd throw it out there.
