### PR TITLE
Defer compile

### DIFF
--- a/lib/handlebars/compiler/compiler.js
+++ b/lib/handlebars/compiler/compiler.js
@@ -753,16 +753,21 @@ Handlebars.precompile = function(string, options) {
   return new Handlebars.JavaScriptCompiler().compile(environment, options);
 };
 
-Handlebars.compile = function(string, compileOptions) {
-  var compiled;
-  compileOptions = compileOptions || {};
+Handlebars.compile = function(string, options) {
+  options = options || {};
 
+  var compiled;
+  function compile() {
+    var ast = Handlebars.parse(string);
+    var environment = new Handlebars.Compiler().compile(ast, options);
+    var templateSpec = new Handlebars.JavaScriptCompiler().compile(environment, options, undefined, true);
+    return Handlebars.template(templateSpec);
+  }
+
+  // Template is only compiled on first use and cached after that point.
   return function(context, options) {
     if (!compiled) {
-      var ast = Handlebars.parse(string);
-      var environment = new Handlebars.Compiler().compile(ast, options);
-      var templateSpec = new Handlebars.JavaScriptCompiler().compile(environment, options, undefined, true);
-      compiled = Handlebars.template(templateSpec);
+      compiled = compile();
     }
     return compiled.call(this, context, options);
   };


### PR DESCRIPTION
Defers template parsing and compilation until first use. Provides a pretty drastic drop in app startup time for non-precompiled case.
