### PR TITLE
Broken code when putting js after generated block.

### DIFF
--- a/bin/handlebars
+++ b/bin/handlebars
@@ -121,7 +121,7 @@ argv._.forEach(function(template) {
 
 // Output the content
 if (!argv.simple) {
-  output.push('})()');
+  output.push('})();');
 }
 output = output.join('');
 


### PR DESCRIPTION
Added a semicolon to the end of the generated anonymous javascript function since it could break code following it.
Example: (function(){})()/\* this is the same as undefined() */(function(){})()
