### PR TITLE
Params which are functions should be resolved before use

### DIFF
--- a/spec/qunit_spec.js
+++ b/spec/qunit_spec.js
@@ -510,6 +510,13 @@ test("simple multi-params work", function() {
   shouldCompileTo(string, [hash, helpers], "Message: Goodbye cruel world", "regular helpers with multiple params");
 });
 
+test("functions as multi-params work", function() {
+  var string   = 'Message: {{goodbye descriptor location}}';
+  var hash     = {descriptor: function() { return "cruel"}, location: function(){return "world"}}
+  var helpers = {goodbye: function(desc, loc) { return "Goodbye " + desc + " " + loc; }}
+  shouldCompileTo(string, [hash, helpers], "Message: Goodbye cruel world", "regular helpers with func params");
+});
+
 test("block multi-params work", function() {
   var string   = 'Message: {{#goodbye cruel world}}{{greeting}} {{adj}} {{noun}}{{/goodbye}}';
   var hash     = {cruel: "cruel", world: "world"}


### PR DESCRIPTION
If the first thing inside the {{}} is a function name (either a helper, or a method of the data object), it gets resolved - good.  But if the parameters to that thing are themselves functions, they aren't resolved before being sent to the first function.

Here's a failing test for this.  I made an effort to solve this but I blew out my timebox, not being familiar with Bison et al.  
