### PR TITLE
Compatibility with Mozilla Rhino

### DIFF
--- a/src/handlebars.l
+++ b/src/handlebars.l
@@ -27,7 +27,7 @@
 <mu>"true"/[}\s]             { return 'BOOLEAN'; }
 <mu>"false"/[}\s]            { return 'BOOLEAN'; }
 <mu>[0-9]+/[}\s]             { return 'INTEGER'; }
-<mu>[a-zA-Z0-9_$-]+/[=}\s/.] { return 'ID'; }
+<mu>[a-zA-Z0-9_$-]+/[=}\s\/.] { return 'ID'; }
 <mu>\[.*\]                   { yytext = yytext.substr(1, yyleng-2); return 'ID'; }
 <mu>.                        { return 'INVALID'; }
 


### PR DESCRIPTION
Escaping a '/' in the ID regex. This was preventing handelbars.js from loading in Rhino.

Rebased version of #49.
