### PR TITLE
Fix support for Rhino

### DIFF
--- a/src/handlebars.l
+++ b/src/handlebars.l
@@ -19,7 +19,7 @@
 <mu>"="                      { return 'EQUALS'; }
 <mu>"."/[} ]                 { return 'ID'; }
 <mu>".."                     { return 'ID'; }
-<mu>[/.]                     { return 'SEP'; }
+<mu>[\/.]                    { return 'SEP'; }
 <mu>\s+                      { /*ignore whitespace*/ }
 <mu>"}}}"                    { this.begin("INITIAL"); return 'CLOSE'; }
 <mu>"}}"                     { this.begin("INITIAL"); return 'CLOSE'; }


### PR DESCRIPTION
The rules get compiled to /regex/, this particular one goes to something like

  /[/.]/

Rhino's regex parser must be a bit whack.
