### PR TITLE
properly handle ampersands when HTML escaping

### DIFF
--- a/lib/handlebars/utils.js
+++ b/lib/handlebars/utils.js
@@ -22,6 +22,7 @@ Handlebars.SafeString.prototype.toString = function() {
 
 (function() {
   var escape = {
+    "&": "&amp;",
     "<": "&lt;",
     ">": "&gt;",
     '"': "&quot;",
@@ -29,7 +30,7 @@ Handlebars.SafeString.prototype.toString = function() {
     "`": "&#x60;"
   };
 
-  var badChars = /&(?!\w+;)|[<>"'`]/g;
+  var badChars = /[&<>"'`]/g;
   var possible = /[&<>"'`]/;
 
   var escapeChar = function(chr) {

--- a/spec/qunit_spec.js
+++ b/spec/qunit_spec.js
@@ -96,6 +96,8 @@ test("escaping expressions", function() {
  shouldCompileTo("{{awesome}}", {awesome: "&\"'`\\<>"}, '&amp;&quot;&#x27;&#x60;\\&lt;&gt;',
         "by default expressions should be escaped");
 
+ shouldCompileTo("{{awesome}}", {awesome: "Escaped, <b> looks like: &lt;b&gt;"}, 'Escaped, &lt;b&gt; looks like: &amp;lt;b&amp;gt;',
+        "escaping should properly handle amperstands");
 });
 
 test("functions returning safestrings shouldn't be escaped", function() {


### PR DESCRIPTION
escapeExpression, when given a string like `"&gt;"`, was simply returning
`"&gt;"`, not escaping the ampersand. This is incorrect, and makes it
impossible to have Handlebars properly escape a
string like `"Escaped, <b> looks like: &lt;b&gt;"`

If the intention of the user is to not escape these characters, then
{{{}}} or {{&}} should be used
