### PR TITLE
add separator support in `each`

### DIFF
--- a/lib/handlebars/base.js
+++ b/lib/handlebars/base.js
@@ -56,12 +56,14 @@ Handlebars.registerHelper('blockHelperMissing', function(context, options) {
 
 Handlebars.registerHelper('each', function(context, options) {
   var fn = options.fn, inverse = options.inverse;
+  var sep = options.hash.sep || "";
   var ret = "";
 
   if(context && context.length > 0) {
-    for(var i=0, j=context.length; i<j; i++) {
-      ret = ret + fn(context[i]);
+    for(var i=0, j=context.length, ret=[]; i<j; i++) {
+      ret.push(fn(context[i]));
     }
+    ret = ret.join(sep);
   } else {
     ret = inverse(this);
   }


### PR DESCRIPTION
Hello,

with this commit, `each` accepts a `sep` hash argument that is used as separator.

For example:

```
var hb = require('handlebars');
var render = hb.compile('{{#each items sep=","}}{{this}}{{/each}}');
var data = {
    items: [ "foo", "bar", "baz" ]
};

console.log(render(data));
```

outputs

```
foo,bar,baz
```

I need this for a project, maybe it could come handy for others too.

Cheers,
Giacomo
