### PR TITLE
Block helper "with" should check for empty context

### DIFF
--- a/lib/handlebars/base.js
+++ b/lib/handlebars/base.js
@@ -88,7 +88,7 @@ Handlebars.registerHelper('unless', function(context, options) {
 });
 
 Handlebars.registerHelper('with', function(context, options) {
-  return options.fn(context);
+  if (!Handlebars.Utils.isEmpty(context)) return options.fn(context);
 });
 
 Handlebars.registerHelper('log', function(context) {


### PR DESCRIPTION
Add a simple check to the 'with' block helper for an empty context. I think the behavior - no output with an empty context - is unsurprising at worst, expected at best, and will prevent "cannot read property of undefined" errors.
