### PR TITLE
Adding using a 'class' variable name as a 'known issue'

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -283,6 +283,7 @@ template(context, {helpers: helpers, partials: partials, data: data})
 Known Issues
 ------------
 * Handlebars.js can be cryptic when there's an error while rendering.
+* Using a variable, helper, or partial named `class` causes errors in IE browsers. (Instead, use `className`)
 
 Handlebars in the Wild
 -----------------


### PR DESCRIPTION
Probably shouldn't fix it, but since technically we could use string notation, I put it under known issues. Just something for people to be aware of.

Initially reported at: https://github.com/SlexAxton/require-handlebars-plugin/issues/17
