### PR TITLE
Requires the file package to work in node or browserify.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   },
   "dependencies": {
     "optimist": "~0.3",
-    "uglify-js": "~1.2"
+    "uglify-js": "~1.2",
+    "file": "*"
   },
   "devDependencies": {},
   "main": "lib/handlebars.js",


### PR DESCRIPTION
Handlebars depends on the "file" npm package to function under browserify or node.js.
