### PR TITLE
isEmpty should check for empty objects

### DIFF
--- a/lib/handlebars/utils.js
+++ b/lib/handlebars/utils.js
@@ -56,11 +56,20 @@ Handlebars.SafeString.prototype.toString = function() {
         return true;
       } else if (value === false) {
         return true;
-      } else if(Object.prototype.toString.call(value) === "[object Array]" && value.length === 0) {
+      } else if (Object.prototype.toString.call(value) === "[object Array]" && value.length === 0) {
+        return true;
+      } else if (Object.prototype.toString.call(value) === "[object Object]" && this.isEmptyObject(value)) {
         return true;
       } else {
         return false;
       }
+    },
+
+    isEmptyObject: function(obj) {
+      for (var name in obj) {
+        return false;
+      }
+      return true;
     }
   };
 })();


### PR DESCRIPTION
I understand this [part](http://handlebarsjs.com/#conditionals) of the documentation

> when used with an empty ({}) context, will result in:

as if you have an empty object, the value will be considered "falsy".
Handlebars.Utils.isEmpty(context) has no check for empty objects, so did I just understand the documentation wrong?

Anyhow, I would like to have a check on empty objects, thus the pull request. :)
