### PR TITLE
Added object traversal support to {{#each}} helper.

### DIFF
--- a/lib/handlebars/base.js
+++ b/lib/handlebars/base.js
@@ -58,7 +58,7 @@ Handlebars.registerHelper('each', function(context, options) {
   var i=0, n, fn = options.fn, inverse = options.inverse, ret = '';
 	
   if(context) {
-    if (Array.isArray(context)) {
+    if(typeof context === 'object' && typeof context.length === 'number') {
       for(i=0, n=context.length; i<n; i++) {
         ret = ret + fn(context[i]);
       }


### PR DESCRIPTION
Being able to traverse keyed objects with the `{{#each}}` helper is super helpful—right now it only supports arrays. Here's an example:

``` javascript
var sections = {
    home : { title: 'Welcome', message: 'Blah' },
    faq  : { title: 'FAQ', message: 'These are questions' }
};
```

With this update, it's now possible to traverse it:

``` html
{{#each}}
    {{this.title}} - {{this.message}}
{{/each}}
```

Without this change, you have to pick out the values just for handlebars using `_.values()` (or manually, if you're not using something like underscore)—which is really inconvenient.
