### PR TITLE
partialName can now be a property. Fixes #189

### DIFF
--- a/lib/handlebars/runtime.js
+++ b/lib/handlebars/runtime.js
@@ -47,6 +47,12 @@ Handlebars.VM = {
   },
   noop: function() { return ""; },
   invokePartial: function(partial, name, context, helpers, partials, data) {
+    
+    if(partial == undefined && context[name] != undefined && partials[context[name]] != undefined){
+      name = context[name];
+      partial = partials[name];
+    }
+    
     var options = { helpers: helpers, partials: partials, data: data };
 
     if(partial === undefined) {


### PR DESCRIPTION
if a partial with the specified name could not be found it will handle the name as a property.
