### PR TITLE
AMD support (second proposal)

### DIFF
--- a/bin/handlebars
+++ b/bin/handlebars
@@ -7,6 +7,17 @@ var optimist = require('optimist')
         'description': 'Output File',
         'alias': 'output'
       },
+      'a': {
+        'type': 'boolean',
+        'description': 'Exports amd style (require.js)',
+        'alias': 'amd'
+      },
+      'h': {
+        'type': 'string',
+        'description': 'Path to handlebar.js (only valid for amd-style)',
+        'alias': 'handlebarPath',
+		'default': ''
+      },
       'k': {
         'type': 'string',
         'description': 'Known helpers',
@@ -78,7 +89,12 @@ if (argv.known) {
 
 var output = [];
 if (!argv.simple) {
-  output.push('(function() {\n  var template = Handlebars.template, templates = Handlebars.templates = Handlebars.templates || {};\n');
+  if (argv.amd) {
+    output.push('define([\'' + argv.handlebarPath + 'handlebars\'], function(Handlebars) {\n');
+  } else {
+    output.push('(function() {\n');
+  }
+  output.push('  var template = Handlebars.template, templates = Handlebars.templates = Handlebars.templates || {};\n');
 }
 function processTemplate(template, root) {
   var path = template,
@@ -121,7 +137,11 @@ argv._.forEach(function(template) {
 
 // Output the content
 if (!argv.simple) {
-  output.push('})();');
+  if (argv.amd) {
+    output.push('});');
+  } else {
+    output.push('})();');
+  }
 }
 output = output.join('');
 


### PR DESCRIPTION
After pull #187 did not sattisfy my need for an adaption of the template compilation into an AMD-style module the neccessary changes introducing two commandline flags to enable AMD style compile handlebar templates (-a, --amd) and another one to specify ones path to handlebar(.js).

Please note: this only afflicts compile template files.

PS: This is (another) solution to issue #145
