### PR TITLE
add safeString as standard function

### DIFF
--- a/lib/handlebars/base.js
+++ b/lib/handlebars/base.js
@@ -111,6 +111,12 @@ Handlebars.registerHelper('log', function(context) {
   Handlebars.log(context);
 });
 
+Handlebars.registerHelper('safeString', function(string) {
+  return new Handlebars.SafeString(
+    string
+  );
+});
+
 }());
 
 // END(BROWSER)


### PR DESCRIPTION
Similar to {{{ }}} but as standard function.

Note: I don't have the build env. set up for handlebars. (Tested by changing the js that can be downloaded)

Usage:

{{safeString someHtml}}
