### PR TITLE
Fixed an issue where {{#array}} {{/array}} wouldn't pass in an @index data variable

### DIFF
--- a/lib/handlebars/base.js
+++ b/lib/handlebars/base.js
@@ -44,13 +44,10 @@ Handlebars.registerHelper('blockHelperMissing', function(context, options) {
     return inverse(this);
   } else if(type === "[object Array]") {
     if(context.length > 0) {
-      for(var i=0, j=context.length; i<j; i++) {
-        ret = ret + fn(context[i]);
-      }
+      return Handlebars.helpers.each(context, options);
     } else {
-      ret = inverse(this);
+      return inverse(this);
     }
-    return ret;
   } else {
     return fn(context);
   }

--- a/spec/qunit_spec.js
+++ b/spec/qunit_spec.js
@@ -234,6 +234,16 @@ test("array", function() {
 
 });
 
+test("array with @index", function() {
+  var string = "{{#goodbyes}}{{@index}}. {{text}}! {{/goodbyes}}cruel {{world}}!";
+  var hash   = {goodbyes: [{text: "goodbye"}, {text: "Goodbye"}, {text: "GOODBYE"}], world: "world"};
+
+  var template = CompilerContext.compile(string);
+  var result = template(hash);
+
+  equal(result, "0. goodbye! 1. Goodbye! 2. GOODBYE! cruel world!", "The @index variable is used");
+});
+
 test("empty block", function() {
   var string   = "{{#goodbyes}}{{/goodbyes}}cruel {{world}}!";
   var hash     = {goodbyes: [{text: "goodbye"}, {text: "Goodbye"}, {text: "GOODBYE"}], world: "world"};


### PR DESCRIPTION
See demonstration here:
http://jsbin.com/anamug/4/edit

Just think it's nice if this one and {{#each}} behaves the same

Anyhow, thanks the good job with Handlebars, it's great!
