### PR TITLE
Ensure plain text partials supplied to registerPartials are compiled using data: true if necessary.

### DIFF
--- a/lib/handlebars/runtime.js
+++ b/lib/handlebars/runtime.js
@@ -56,7 +56,7 @@ Handlebars.VM = {
     } else if (!Handlebars.compile) {
       throw new Handlebars.Exception("The partial " + name + " could not be compiled when running in runtime-only mode");
     } else {
-      partials[name] = Handlebars.compile(partial);
+      partials[name] = Handlebars.compile(partial, {data: data !== undefined});
       return partials[name](context, options);
     }
   }


### PR DESCRIPTION
This works because `Compiler.invokePartial` only add's the final parameter if the outer template has `data: true` set in it's options.

I'm unsure how to unit test this change though..
