### PR TITLE
fix error inheritance and capture the stack trace in V8

### DIFF
--- a/lib/handlebars/utils.js
+++ b/lib/handlebars/utils.js
@@ -3,6 +3,7 @@ var Handlebars = require("./base");
 // BEGIN(BROWSER)
 Handlebars.Exception = function(message) {
   Error.prototype.constructor.apply(this, arguments);
+  this.message = message;
   Error.captureStackTrace ? Error.captureStackTrace(this,Handlebars.Exception) : null;
 };
 


### PR DESCRIPTION
Handlebars' exceptions all think they come from utils.js, line 13, 'cause that's where the call to `new Error` is. that's not good.

this patch cribs from Coco/LiveScript's class inheritance so as we don't bork the `constructor` property, then calls V8's Error.captureStackTrace just in case.
