### PR TITLE
Add missing var

### DIFF
--- a/lib/handlebars/compiler/compiler.js
+++ b/lib/handlebars/compiler/compiler.js
@@ -96,7 +96,7 @@ Handlebars.JavaScriptCompiler = function() {};
       this.children[guid] = result;
 
       for(var i=0, l=result.depths.list.length; i<l; i++) {
-        depth = result.depths.list[i];
+        var depth = result.depths.list[i];
 
         if(depth < 2) { continue; }
         else { this.addDepth(depth - 1); }
@@ -854,7 +854,7 @@ Handlebars.JavaScriptCompiler = function() {};
       var programParams = [child.index, child.name, "data"];
 
       for(var i=0, l = depths.length; i<l; i++) {
-        depth = depths[i];
+        var depth = depths[i];
 
         if(depth === 1) { programParams.push("depth0"); }
         else { programParams.push("depth" + (depth - 1)); }


### PR DESCRIPTION
I found symbol "depth" is leaking to global scope due to missing "var" declarations.
