### PR TITLE
Makes Handlebars.log available in both builds and fleshes out `log` helper.

### DIFF
--- a/lib/handlebars/base.js
+++ b/lib/handlebars/base.js
@@ -62,6 +62,24 @@ Handlebars.createFrame = Object.create || function(object) {
   return obj;
 };
 
+Handlebars.logger = {
+  DEBUG: 0, INFO: 1, WARN: 2, ERROR: 3, level: 3,
+
+  methodMap: {0: 'debug', 1: 'info', 2: 'warn', 3: 'error'},
+
+  // can be overridden in the host environment
+  log: function(level, obj) {
+    if (Handlebars.logger.level <= level) {
+      var method = Handlebars.logger.methodMap[level];
+      if (typeof console !== 'undefined' && console[method]) {
+        console[method].call(console, obj);
+      }
+    }
+  }
+};
+
+Handlebars.log = function(level, obj) { Handlebars.logger.log(level, obj); };
+
 Handlebars.registerHelper('each', function(context, options) {
   var fn = options.fn, inverse = options.inverse;
   var i = 0, ret = "", data;
@@ -117,8 +135,9 @@ Handlebars.registerHelper('with', function(context, options) {
   return options.fn(context);
 });
 
-Handlebars.registerHelper('log', function(context) {
-  Handlebars.log(context);
+Handlebars.registerHelper('log', function(context, options) {
+  var level = options.data && options.data.level != null ? parseInt(options.data.level, 10) : 1;
+  Handlebars.log(level, context);
 });
 
 }(this.Handlebars));

--- a/lib/handlebars/compiler/base.js
+++ b/lib/handlebars/compiler/base.js
@@ -12,16 +12,6 @@ Handlebars.parse = function(string) {
 Handlebars.print = function(ast) {
   return new Handlebars.PrintVisitor().accept(ast);
 };
-
-Handlebars.logger = {
-  DEBUG: 0, INFO: 1, WARN: 2, ERROR: 3, level: 3,
-
-  // override in the host environment
-  log: function(level, str) {}
-};
-
-Handlebars.log = function(level, str) { Handlebars.logger.log(level, str); };
-
 // END(BROWSER)
 
 module.exports = Handlebars;


### PR DESCRIPTION
This gets a _bit_ overzealous with using the different `console.debug`, `console.info`, `console.warm`, `console.error` methods.  Perhaps it should be simpler (and less bytes) by just calling `console.log`.  
