### PR TITLE
Enabling custom template extension

### DIFF
--- a/bin/handlebars
+++ b/bin/handlebars
@@ -42,6 +42,12 @@ var optimist = require('optimist')
         'type': 'string',
         'description': 'Template root. Base value that will be stripped from template names.',
         'alias': 'root'
+      },
+      'e': {
+        'type': 'string',
+        'description': 'Template extension.',
+        'alias': 'extension',
+        'default': 'handlebars'
       }
     })
 
@@ -87,6 +93,9 @@ if (argv.known) {
   }
 }
 
+// Build file extension pattern
+var extension = new RegExp('\\.' + argv.extension + '$');
+
 var output = [];
 if (!argv.simple) {
   if (argv.amd) {
@@ -103,7 +112,7 @@ function processTemplate(template, root) {
     fs.readdirSync(template).map(function(file) {
       var path = template + '/' + file;
 
-      if (/\.handlebars$/.test(path) || fs.statSync(path).isDirectory()) {
+      if (extension.test(path) || fs.statSync(path).isDirectory()) {
         processTemplate(path, root || template);
       }
     });
@@ -121,7 +130,7 @@ function processTemplate(template, root) {
     } else if (template.indexOf(root) === 0) {
       template = template.substring(root.length+1);
     }
-    template = template.replace(/\.handlebars$/, '');
+    template = template.replace(extension, '');
 
     if (argv.simple) {
       output.push(handlebars.precompile(data, options) + '\n');


### PR DESCRIPTION
Hi guys, when working out with express.js and its connect handlebars module, I find extremely useful to work with `hbs` extension because it keeps everything shorter and is the default one.
However, when adding custom build scripts to precompile templates I find it annoying as the `hbs` extension remains in the template name.

With this commit I added an additional, optional, parameter to specify the template extension so that it could get easily removed from template name. The parameter has its default value set to `handlebars` as to be consistent with the current implementation.

Thank you for your great work!
