### PR TITLE
Support function arguments to with blocks

### DIFF
--- a/lib/handlebars/base.js
+++ b/lib/handlebars/base.js
@@ -114,7 +114,11 @@ Handlebars.registerHelper('unless', function(context, options) {
 });
 
 Handlebars.registerHelper('with', function(context, options) {
-  return options.fn(context);
+  if(typeof(context) === 'function') {
+    return options.fn(context.apply())
+  } else {
+    return options.fn(context);
+  }
 });
 
 Handlebars.registerHelper('log', function(context) {

--- a/spec/qunit_spec.js
+++ b/spec/qunit_spec.js
@@ -653,6 +653,11 @@ test("with", function() {
   shouldCompileTo(string, {person: {first: "Alan", last: "Johnson"}}, "Alan Johnson");
 });
 
+test("with with function argument", function() {
+  var string = "{{#with person}}{{first}} {{last}}{{/with}}";
+  shouldCompileTo(string, {person: function() { return {first: "Alan", last: "Johnson"}}}, "Alan Johnson");
+});
+
 test("if", function() {
   var string   = "{{#if goodbye}}GOODBYE {{/if}}cruel {{world}}!";
   shouldCompileTo(string, {goodbye: true, world: "world"}, "GOODBYE cruel world!",


### PR DESCRIPTION
The current implementation of 'with' blocks doesn't seem to make much sense if the context passed in is a function rather than an object.

Executing the function and using the results in this case allows for an object to have context-generating functions without any obvious downsides.
