### PR TITLE
Issue #364 - Fix IE9 blank cell bug 

### DIFF
--- a/lib/handlebars/compiler/compiler.js
+++ b/lib/handlebars/compiler/compiler.js
@@ -1045,7 +1045,10 @@ Handlebars.precompile = function(string, options) {
 Handlebars.compile = function(string, options) {
   options = options || {};
 
-  var compiled;
+  var compiled,
+      re = /(\<t.{1-4}>)\s+|\s+(\<\/t.{1-4}\>)|\\r|\\n/gim, 
+      string = string.replace(re, '$1'); 
+
   function compile() {
     var ast = Handlebars.parse(string);
     var environment = new Handlebars.Compiler().compile(ast, options);


### PR DESCRIPTION
In IE9, if you have whitespace and/or carriage returns between table
elements, it causes IE9 to render a blank column and pushes all the
content one column to the right.  It seems the best solution is to
strip it out of the template string when you compile a template.

If you search google for "IE9 renders blank cells" you'll find lots of
references to this problem.
