### PR TITLE
added 'include' helper for #182

### DIFF
--- a/lib/handlebars/base.js
+++ b/lib/handlebars/base.js
@@ -121,6 +121,16 @@ Handlebars.registerHelper('log', function(context) {
   Handlebars.log(context);
 });
 
+Handlebars.registerHelper('include', function(name, options) {
+  var context  = {},
+  mergeContext = function(obj) {
+    for(var k in obj)context[k]=obj[k];
+  };
+  mergeContext(this);
+  mergeContext(options.hash);
+  return new Handlebars.SafeString(Handlebars.VM.invokePartial(Handlebars.partials[name], name, context, {}, Handlebars.partials));
+});
+
 }(this.Handlebars));
 
 // END(BROWSER)

--- a/lib/handlebars/compiler/compiler.js
+++ b/lib/handlebars/compiler/compiler.js
@@ -55,7 +55,8 @@ Handlebars.JavaScriptCompiler = function() {};
         'if': true,
         'unless': true,
         'with': true,
-        'log': true
+        'log': true,
+        'include': true
       };
       if (knownHelpers) {
         for (var name in knownHelpers) {

--- a/spec/qunit_spec.js
+++ b/spec/qunit_spec.js
@@ -730,6 +730,15 @@ test("each with @index", function() {
   equal(result, "0. goodbye! 1. Goodbye! 2. GOODBYE! cruel world!", "The @index variable is used");
 });
 
+test("include partials with extendend contexts", function() {
+  var
+    string  = '{{#each dudes}}{{include "dude" greeting=..}} {{/each}}',
+    hash = {hello: "Hi", dudes: [{name: "Yehuda", url: "http://yehuda"}, {name: "Alan", url: "http://alan"}]},
+    partial = "{{greeting.hello}}, {{name}}!";
+  Handlebars.registerPartial('dude', partial);
+  shouldCompileToWithPartials(string, [hash], true, "Hi, Yehuda! Hi, Alan! ");
+});
+
 test("log", function() {
   var string = "{{log blah}}";
   var hash   = { blah: "whee" };


### PR DESCRIPTION
I added an "include" helper to allow passing of distinct objects down to the partial. Mainly inspired by @chickenwing and @ustun.
I did so after investigating into the structure of the compiler because I didn't see any obvious solution to reference the correct context (mainly due to missing knowledge about bison compilers in general).

Caveat: The helper only finds partials that are correctly registered and not passed in through compile options.
