### PR TITLE
Add CommonJS export option for template compilation.

### DIFF
--- a/bin/handlebars
+++ b/bin/handlebars
@@ -12,11 +12,17 @@ var optimist = require('optimist')
         'description': 'Exports amd style (require.js)',
         'alias': 'amd'
       },
+      'c': {
+        'type': 'string',
+        'description': 'Exports CommonJS style, path to Handlebars module',
+        'alias': 'commonjs',
+        'default': null
+      },
       'h': {
         'type': 'string',
         'description': 'Path to handlebar.js (only valid for amd-style)',
         'alias': 'handlebarPath',
-		'default': ''
+		    'default': ''
       },
       'k': {
         'type': 'string',
@@ -91,6 +97,8 @@ var output = [];
 if (!argv.simple) {
   if (argv.amd) {
     output.push('define([\'' + argv.handlebarPath + 'handlebars\'], function(Handlebars) {\n');
+  } else if (argv.commonjs) {
+    output.push('var Handlebars = require("' + argv.commonjs + '");');
   } else {
     output.push('(function() {\n');
   }
@@ -139,7 +147,7 @@ argv._.forEach(function(template) {
 if (!argv.simple) {
   if (argv.amd) {
     output.push('});');
-  } else {
+  } else if (!argv.commonjs) {
     output.push('})();');
   }
 }


### PR DESCRIPTION
This change allows to export the compiled Templates as CommonJS by specifying the module name of the Handlebars runtime.

Example:

```
bin/handlebars -c "HandlebarsRuntime" […]
```

results in the following Output:

``` javascript
var Handlebars = require('HandlebarsRuntime');

[...] // compiled Templates
```

This is useful when working in a CommonJS Context :)
