### PR TITLE
Making AMD module output return compiled function when only one template is processed

### DIFF
--- a/bin/handlebars
+++ b/bin/handlebars
@@ -134,7 +134,8 @@ function processTemplate(template, root) {
     if (argv.simple) {
       output.push(handlebars.precompile(data, options) + '\n');
     } else {
-      output.push('return templates[\'' + template + '\'] = template(' + handlebars.precompile(data, options) + ');\n');
+      if(argv._.length === 1){ output.push('return '); }
+      output.push('templates[\'' + template + '\'] = template(' + handlebars.precompile(data, options) + ');\n');
     }
   }
 }


### PR DESCRIPTION
Using Handlebars in an AMD environment, it would be helpful to return the compiled function from the AMD module.

To minimize impact on your current logic, I have only implemented this modification for when one template is being precompiled.
