### PR TITLE
Resolve possible lambdas for partials

### DIFF
--- a/lib/handlebars/compiler/compiler.js
+++ b/lib/handlebars/compiler/compiler.js
@@ -165,6 +165,7 @@ Handlebars.JavaScriptCompiler = function() {};
 
       if(partial.context) {
         this.ID(partial.context);
+        this.opcode('resolvePossibleLambda');
       } else {
         this.opcode('push', 'depth0');
       }

--- a/spec/qunit_spec.js
+++ b/spec/qunit_spec.js
@@ -482,6 +482,14 @@ test("partials with context", function() {
                   "Partials can be passed a context");
 });
 
+test("partials resolve context which is lambda", function() {
+  var string = "Path lambdas: {{>result lambda}}";
+  var partial = "implemented for {{name}}";
+  var hash = {lambda: function() { return {name: 'Handlebars'}}};
+  shouldCompileToWithPartials(string, [hash, {}, {result: partial}], true, "Path lambdas: implemented for Handlebars",
+                  "Partials can be passed a context");
+});
+
 test("partial in a partial", function() {
   var string = "Dudes: {{#dudes}}{{>dude}}{{/dudes}}";
   var dude = "{{name}} {{> url}} ";


### PR DESCRIPTION
Hi @wycats,

I just ran across this today. We are using fairly complex context objects and wanted to invoke a partial with a context that was a function not a property. Let me illustrate with a completely contrived example. WIth this context:

```
{ first: function() { return this.data[0]}, data: [{name: 'Handlebars'}]};
```

And this partial invocation:

```
{{> partial first}}
```

The result for a simple partial of `Name: {{name}}` should be "Name: Handlebars".

This might resolve #182 and remove the need for #368

I am bummed that I missed the `ember.js` talk, if you are around Seattle tomorrow (Friday) I would like to buy you a coffee at Victrola on Pike (really great coffee).
