### PR TITLE
Resolve possible lambdas in paths

### DIFF
--- a/lib/handlebars/compiler/compiler.js
+++ b/lib/handlebars/compiler/compiler.js
@@ -249,6 +249,7 @@ Handlebars.JavaScriptCompiler = function() {};
       }
 
       for(var i=1, l=id.parts.length; i<l; i++) {
+        this.opcode('resolvePossibleLambda');
         this.opcode('lookup', id.parts[i]);
       }
     },

--- a/spec/qunit_spec.js
+++ b/spec/qunit_spec.js
@@ -175,6 +175,16 @@ test("nested paths with empty string value", function() {
                   "Goodbye  world!", "Nested paths access nested objects with empty string");
 });
 
+test("nested paths with lambdas", function() {
+  shouldCompileTo("{{outer}} paths with {{nested.inner}}!", {outer: 'Nested', nested: function() { return {inner: 'lambdas'};}},
+                  "Nested paths with lambdas!", "Nested paths evaluate lambdas");
+});
+
+test("deeply nested paths with lambdas", function() {
+  shouldCompileTo("{{outer}} paths with {{one.two.inner}}!", {outer: 'Nested', one: {two: function() { return {inner: 'lambdas'};}}},
+                  "Nested paths with lambdas!", "Nested paths evaluate lambdas");
+});
+
 test("literal paths", function() {
 	shouldCompileTo("Goodbye {{[@alan]/expression}} world!", {"@alan": {expression: "beautiful"}},
 			"Goodbye beautiful world!", "Literal paths can be used");


### PR DESCRIPTION
Hi @wycats,

Very similar to yesterday's [PR](https://github.com/wycats/handlebars.js/pull/383). When walking down the path of an ID we need to check whether each path component is a lambda.
