### PR TITLE
New Helper: Each Include Parent - (Works with partials)

### DIFF
--- a/lib/handlebars/base.js
+++ b/lib/handlebars/base.js
@@ -121,6 +121,70 @@ Handlebars.registerHelper('log', function(context) {
   Handlebars.log(context);
 });
 
+Handlebars.registerHelper('eachIncludeParent', function (context, options) {
+
+  function _each (obj, callback, args) {
+    var name,
+      i = 0,
+      length = obj.length,
+      isObj = length === undefined;
+
+    if(args) {
+      if(isObj) {
+        for(name in obj) {
+          if(callback.apply(obj[name], args) === false) {
+            break;
+          }
+        }
+      } else {
+        for(; i < length;) {
+          if (callback.apply(obj[i++], args) === false) {
+            break;
+          }
+        }
+      }
+    } else {
+      if (isObj) {
+        for (name in obj) {
+          if (callback.call(obj[name], name, obj[name]) === false) {
+            break;
+          }
+        }
+      } else {
+        for (; i < length;) {
+          if (callback.call(obj[i], i, obj[i++]) === false) {
+            break;
+          }
+        }
+      }
+    }
+
+    return obj;
+  };
+  
+  var fn = options.fn,
+  inverse = options.inverse,
+  ret = "",
+  _context = [];
+
+  _each(context, function(index, object) {
+    var _object = {};
+    for (var key in object) if (object.hasOwnProperty(key)) _object[key] = object[key];
+    _context.push(_object);
+  });
+
+  if (_context && _context.length > 0) {
+    for (var i = 0, j = _context.length; i < j; i++) {
+      _context[i]["parentContext"] = options.hash.parent;
+      ret = ret + fn(_context[i]);
+    }
+  } else {
+    ret = inverse(this);
+  }
+
+  return ret;
+});
+
 }(this.Handlebars));
 
 // END(BROWSER)


### PR DESCRIPTION
This helper allows a parent context to be accessed when using partial templates inside of an each.
Note: It has no dependencies other than Handlebars. Uses a local _each function that is a port of jQuey.each.
Usage: {{#eachIncludeParent context parent=this}}{{> template-partial }}{{/eachIncludeParent}}
See demo: jsFiddle - http://jsfiddle.net/AndrewHenderson/kQZpu/5/
Comment Thread: https://github.com/wycats/handlebars.js/issues/182#issuecomment-11151298
