### PR TITLE
Allow empty blocks around simple inverses

### DIFF
--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -253,6 +253,130 @@ describe "Parser" do
     end
   end
 
+  it "parses an inverse ('else'-style) section" do
+    ast_for("{{#foo}} bar {{else}} baz {{/foo}}").should == root do
+      block do
+        mustache id("foo")
+
+        program do
+          content " bar "
+        end
+
+        inverse do
+          content " baz "
+        end
+      end
+    end
+  end
+
+  it "parses empty blocks" do
+    ast_for("{{#foo}}{{/foo}}").should == root do
+      block do
+        mustache id("foo")
+
+        program do
+          #  empty program
+        end
+      end
+    end
+  end
+
+  it "parses empty blocks with empty inverse section" do
+    ast_for("{{#foo}}{{^}}{{/foo}}").should == root do
+      block do
+        mustache id("foo")
+
+        program do
+          #  empty program
+        end
+
+        inverse do
+          #  empty inverse
+        end
+      end
+    end
+  end
+
+  it "parses empty blocks with empty inverse ('else'-style) section" do
+    ast_for("{{#foo}}{{else}}{{/foo}}").should == root do
+      block do
+        mustache id("foo")
+
+        program do
+          #  empty program
+        end
+
+        inverse do
+          #  empty inverse
+        end
+      end
+    end
+  end
+
+  it "parses non-empty blocks with empty inverse section" do
+    ast_for("{{#foo}} bar {{^}}{{/foo}}").should == root do
+      block do
+        mustache id("foo")
+
+        program do
+          content " bar "
+        end
+
+        inverse do
+          #  empty inverse
+        end
+      end
+    end
+  end
+
+  it "parses non-empty blocks with empty inverse ('else'-style) section" do
+    ast_for("{{#foo}} bar {{else}}{{/foo}}").should == root do
+      block do
+        mustache id("foo")
+
+        program do
+          content " bar "
+        end
+
+        inverse do
+          #  empty inverse
+        end
+      end
+    end
+  end
+
+  it "parses empty blocks with non-empty inverse section" do
+    ast_for("{{#foo}}{{^}} bar {{/foo}}").should == root do
+      block do
+        mustache id("foo")
+
+        program do
+          #  empty program
+        end
+
+        inverse do
+          content " bar "
+        end
+      end
+    end
+  end
+
+  it "parses empty blocks with non-empty inverse ('else'-style) section" do
+    ast_for("{{#foo}}{{else}} bar {{/foo}}").should == root do
+      block do
+        mustache id("foo")
+
+        program do
+          #  empty program
+        end
+
+        inverse do
+          content " bar "
+        end
+      end
+    end
+  end
+
   it "parses a standalone inverse section" do
     ast_for("{{^foo}}bar{{/foo}}").should == root do
       block do

--- a/src/handlebars.yy
+++ b/src/handlebars.yy
@@ -7,8 +7,11 @@ root
   ;
 
 program
-  : statements simpleInverse statements { $$ = new yy.ProgramNode($1, $3); }
+  : simpleInverse statements { $$ = new yy.ProgramNode([], $2); }
+  | statements simpleInverse statements { $$ = new yy.ProgramNode($1, $3); }
+  | statements simpleInverse { $$ = new yy.ProgramNode($1, []); }
   | statements { $$ = new yy.ProgramNode($1); }
+  | simpleInverse { $$ = new yy.ProgramNode([], []); }
   | "" { $$ = new yy.ProgramNode([]); }
   ;
 


### PR DESCRIPTION
The parser currently requires at least one character of whitespace to properly interpret empty blocks around simple inverses.  See here for a [related issue in the IDEA-Handlebars plugin](https://github.com/dmarcotte/idea-handlebars/issues/34).

This is inconsistent with empty block parsing and fairly non-intuitive.  It's also inconsistent with mustache.js (and possibly other mustache implementations, though the spec doesn't give any guidance for this particular case).

(This pull also addresses #251)

Let me know if there's any questions and thanks!
