### PR TITLE
Added new helper of type "comment"

### DIFF
--- a/lib/handlebars/base.js
+++ b/lib/handlebars/base.js
@@ -121,6 +121,11 @@ Handlebars.registerHelper('log', function(context) {
   Handlebars.log(context);
 });
 
+Handlebars.registerHelper('comment', function(context) {
+  return "";
+});
+
+
 }(this.Handlebars));
 
 // END(BROWSER)


### PR DESCRIPTION
Usage:

{{#comment}}
Anything here will be ignored
{{/comment}}

{{comment anything here will be ignored}}

The purpose of this helper is twofold:
1) To allow users to comment out code on the server that will
not be served to the users.
2) Allow commenting code during development without having to delete the code
