### PR TITLE
Readme example typo

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -139,7 +139,7 @@ Handlebars.js also adds the ability to define block helpers. Block helpers are f
 ```js
 var source = "<ul>{{#people}}<li>{{#link}}{{name}}{{/link}}</li>{{/people}}</ul>";
 Handlebars.registerHelper('link', function(context, options) {
-  return '<a href="/people/' + this.id + '">' + context.fn(this) + '</a>';
+  return '<a href="/people/' + this.id + '">' + options.fn(this) + '</a>';
 });
 var template = Handlebars.compile(source);
 


### PR DESCRIPTION
This is pretty trivial but is seems other README example issues mentioned in #314 have been dealt with. While I was looking I thought I'd fix this.

I'll submit pull request against handlebars-site repo for the errors in the site documentation.
