### PR TITLE
README example typo (properly fixed)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -138,7 +138,7 @@ Handlebars.js also adds the ability to define block helpers. Block helpers are f
 
 ```js
 var source = "<ul>{{#people}}<li>{{#link}}{{name}}{{/link}}</li>{{/people}}</ul>";
-Handlebars.registerHelper('link', function(context, options) {
+Handlebars.registerHelper('link', function(options) {
   return '<a href="/people/' + this.id + '">' + options.fn(this) + '</a>';
 });
 var template = Handlebars.compile(source);


### PR DESCRIPTION
Pull request 401 attempted to fix an error but actually introduced one. This corrects it and removes the confusion.

The current README would execute correctly but is very confusing since it shows a callback with `context` and `options` args when the helper has no context parameter. It then actually uses `context.fn()` which works but is very confusing given the convention of calling this hash `options` everywhere else.
