### PR TITLE
Inline ops

### DIFF
--- a/lib/handlebars/compiler/compiler.js
+++ b/lib/handlebars/compiler/compiler.js
@@ -536,6 +536,19 @@ Handlebars.JavaScriptCompiler = function() {};
       }
 
       // Perform a second pass over the output to merge content when possible
+      var source = this.mergeSource();
+
+      if (asObject) {
+        params.push(source);
+
+        return Function.apply(this, params);
+      } else {
+        var functionSource = 'function ' + (this.name || '') + '(' + params.join(',') + ') {\n  ' + source + '}';
+        Handlebars.log(Handlebars.logger.DEBUG, functionSource + "\n\n");
+        return functionSource;
+      }
+    },
+    mergeSource: function() {
       // WARN: We are not handling the case where buffer is still populated as the source should
       // not have buffer append operations as their final action.
       var source = '',
@@ -556,16 +569,7 @@ Handlebars.JavaScriptCompiler = function() {};
           source += line + '\n  ';
         }
       }
-
-      if (asObject) {
-        params.push(source);
-
-        return Function.apply(this, params);
-      } else {
-        var functionSource = 'function ' + (this.name || '') + '(' + params.join(',') + ') {\n  ' + source + '}';
-        Handlebars.log(Handlebars.logger.DEBUG, functionSource + "\n\n");
-        return functionSource;
-      }
+      return source;
     },
 
     // [blockValue]


### PR DESCRIPTION
Implements a variety of performance improvements:
1. Allows stack operations to be inlined via the `,` operator. In many cases this allows us to skip a stack variable or in the case of hashes, inline the hash object as a literal.
2. Merge consecutive buffer concatenation into a single statement
3. Reuse identical programs rather than emitting multiple times
4. Create options register rather than emitting the literal multiple times.

These changes dropped the javascript payload on my project (already running in knownHelpers etc) by about 15kb after minimization (uglify) and about 3kb after gzip.

@wycats Opening a pull request on this as it has some fairly large impact on th readability of the generated template, which may or may not be a concern.

An example of the output:

```
buffer += "This is content\n"
    + "\nThis is more content\n";
  if (stack1 = helpers.mustache) { stack1 = stack1.call(depth0, {hash:{},data:data}); }
  else { stack1 = depth0.mustache; stack1 = typeof stack1 === functionType ? stack1.apply(depth0) : stack1; }
  buffer += escapeExpression(stack1)
    + "\ntest\n"
    + escapeExpression(helpers['if'].call(depth0, {hash:{},data:data}))
    + "\ntest\n";
  options = {hash:{
    'foo': (((stack1 = depth0.bar),stack1 == null || stack1 === false ? stack1 : stack1.bak)),
    'bat': ("bat")
  },data:data};
  buffer += escapeExpression(((stack1 = helpers.helper),stack1 ? stack1.call(depth0, 1, "2", depth0.id, options) : helperMissing.call(depth0, "helper", 1, "2", depth0.id, options)))
    + "\n";

```

Clipped from:

```
This is content
{{! This is a comment}}
This is more content
{{mustache}}
test
{{if}}
test
{{helper 1 "2" id foo=bar.bak bat="bat"}}
```
