### PR TITLE
escapeExpression => Handlebars.Utils.escapeExpression

### DIFF
--- a/lib/handlebars/compiler/compiler.js
+++ b/lib/handlebars/compiler/compiler.js
@@ -598,7 +598,7 @@ Handlebars.JavaScriptCompiler = function() {};
         this.eat(opcode);
       }
 
-      this.source.push(this.appendToBuffer("escapeExpression(" + this.popStack() + ")" + extra));
+      this.source.push(this.appendToBuffer("Handlebars.Utils.escapeExpression(" + this.popStack() + ")" + extra));
     },
 
     // [getContext]


### PR DESCRIPTION
I'm new to handlebars, I just used it in combination with grunt (https://github.com/gruntjs/grunt-contrib-handlebars). The precompiled functions threw "escapeExpression" is not a function - errors.
This change fixed the problem.

But maybe I just used it wrong? I'd appreciate your feedback, if this was indeed a bug or the fault is on my side.
