### PR TITLE
Only allow `this` or `..` to lead a path

### DIFF
--- a/dist/handlebars.js
+++ b/dist/handlebars.js
@@ -726,8 +726,11 @@ Handlebars.print = function(ast) {
     for(var i=0,l=parts.length; i<l; i++) {
       var part = parts[i];
 
-      if(part === "..") { depth++; }
-      else if(part === "." || part === "this") { this.isScoped = true; }
+      if (part === ".." || part === "." || part === "this") {
+        if (dig.length > 0) { throw new Handlebars.Exception("Invalid path: " + this.original); }
+        else if (part === "..") { depth++; }
+        else { this.isScoped = true; }
+      }
       else { dig.push(part); }
     }
 

--- a/lib/handlebars/compiler/ast.js
+++ b/lib/handlebars/compiler/ast.js
@@ -76,8 +76,11 @@ var Handlebars = require('./base');
     for(var i=0,l=parts.length; i<l; i++) {
       var part = parts[i];
 
-      if(part === "..") { depth++; }
-      else if(part === "." || part === "this") { this.isScoped = true; }
+      if (part === ".." || part === "." || part === "this") {
+        if (dig.length > 0) { throw new Handlebars.Exception("Invalid path: " + this.original); }
+        else if (part === "..") { depth++; }
+        else { this.isScoped = true; }
+      }
       else { dig.push(part); }
     }
 

--- a/spec/qunit_spec.js
+++ b/spec/qunit_spec.js
@@ -207,6 +207,13 @@ test("this keyword in paths", function() {
   shouldCompileTo(string, hash, "helloHelloHELLO", "This keyword evaluates in more complex paths");
 });
 
+test("this keyword nested inside path", function() {
+  var string = "{{#hellos}}{{text/this/foo}}{{/hellos}}";
+  shouldThrow(function() {
+      CompilerContext.compile(string);
+    }, Error, "Should throw exception");
+});
+
 test("this keyword in helpers", function() {
   var helpers = {foo: function(value) {
       return 'bar ' + value;
@@ -219,6 +226,13 @@ test("this keyword in helpers", function() {
   string = "{{#hellos}}{{foo this/text}}{{/hellos}}";
   hash = {hellos: [{text: "hello"}, {text: "Hello"}, {text: "HELLO"}]};
   shouldCompileTo(string, [hash, helpers], "bar hellobar Hellobar HELLO", "This keyword evaluates in more complex paths");
+});
+
+test("this keyword nested inside helpers param", function() {
+  var string = "{{#hellos}}{{foo text/this/foo}}{{/hellos}}";
+  shouldThrow(function() {
+      CompilerContext.compile(string);
+    }, Error, "Should throw exception");
 });
 
 suite("inverted sections");
@@ -284,6 +298,14 @@ test("block with complex lookup", function() {
 
   shouldCompileTo(string, hash, "goodbye cruel Alan! Goodbye cruel Alan! GOODBYE cruel Alan! ",
                   "Templates can access variables in contexts up the stack with relative path syntax");
+});
+
+test("block with complex lookup using nested context", function() {
+  var string = "{{#goodbyes}}{{text}} cruel {{foo/../name}}! {{/goodbyes}}";
+
+  shouldThrow(function() {
+      CompilerContext.compile(string);
+    }, Error, "Should throw exception");
 });
 
 test("helper with complex lookup$", function() {


### PR DESCRIPTION
Hi,

This commit just tightens the use of `this` or `..` in paths. Paths like `outer/../key` will raise an exception when compiling.
