### PR TITLE
Check version when evaluating templates.

### DIFF
--- a/dist/handlebars.js
+++ b/dist/handlebars.js
@@ -1380,6 +1380,13 @@ Handlebars.JavaScriptCompiler = function() {};
       // Perform a second pass over the output to merge content when possible
       var source = this.mergeSource();
 
+      if (!this.isChild) {
+        source = "if (Handlebars.VERSION !== '"+Handlebars.VERSION+"') {\n"+
+                   "throw 'Template was compiled with "+Handlebars.VERSION+", but runtime is '+Handlebars.VERSION;\n"+
+                 "}\n"+
+                 source;
+      }
+
       if (asObject) {
         params.push(source);
 

--- a/lib/handlebars/compiler/compiler.js
+++ b/lib/handlebars/compiler/compiler.js
@@ -538,6 +538,13 @@ Handlebars.JavaScriptCompiler = function() {};
       // Perform a second pass over the output to merge content when possible
       var source = this.mergeSource();
 
+      if (!this.isChild) {
+        source = "if (Handlebars.VERSION !== '"+Handlebars.VERSION+"') {\n"+
+                   "throw 'Template was compiled with "+Handlebars.VERSION+", but runtime is '+Handlebars.VERSION;\n"+
+                 "}\n"+
+                 source;
+      }
+
       if (asObject) {
         params.push(source);
 


### PR DESCRIPTION
This makes sure that we throw an error when a template was precompiled with a
version of Handlebars that doesn't match the evaluating version.
