### PR TITLE
Safari undefined str fix

### DIFF
--- a/lib/handlebars/compiler/compiler.js
+++ b/lib/handlebars/compiler/compiler.js
@@ -1112,6 +1112,9 @@ Handlebars.JavaScriptCompiler = function() {};
     },
 
     quotedString: function(str) {
+      if(!str){
+        return;
+      }
       return '"' + str
         .replace(/\\/g, '\\\\')
         .replace(/"/g, '\\"')


### PR DESCRIPTION
On my application Handlebars throws an error only on Safari and the reason is that there is no control over the string passed to the quotedString method. 
UPDATE
It seems that this patch doesn't work properly, I will make a new pull request, I am sorry for that, just ignore it
