### PR TITLE
Quick fix to the Safari undefined string bug

### DIFF
--- a/lib/handlebars/compiler/compiler.js
+++ b/lib/handlebars/compiler/compiler.js
@@ -1112,6 +1112,9 @@ Handlebars.JavaScriptCompiler = function() {};
     },
 
     quotedString: function(str) {
+      if(!str){
+        return '""';
+      }
       return '"' + str
         .replace(/\\/g, '\\\\')
         .replace(/"/g, '\\"')


### PR DESCRIPTION
If the string to quote is undefined Handlebars throws an error only on Safari, this patch fixes the problem returning empty quotes for the undefined strings
