### PR TITLE
Added handlebars-source gemspec

### DIFF
--- a/handlebars-source.gemspec
+++ b/handlebars-source.gemspec
@@ -1,0 +1,21 @@
+# -*- encoding: utf-8 -*-
+require 'json'
+
+package = JSON.parse(File.read('package.json'))
+
+Gem::Specification.new do |gem|
+  gem.name          = "handlebars-source"
+  gem.authors       = ["Yehuda Katz"]
+  gem.email         = ["wycats@gmail.com"]
+  gem.date          = Time.now.strftime("%Y-%m-%d")
+  gem.description   = %q{Handlebars.js source code wrapper for (pre)compilation gems.}
+  gem.summary       = %q{Handlebars.js source code wrapper}
+  gem.homepage      = "https://github.com/wycats/handlebars.js/"
+  gem.version       = package["version"]
+
+  gem.files = [
+    'dist/handlebars.js',
+    'dist/handlebars.runtime.js',
+    'lib/handlebars/source.rb'
+  ]
+end

--- a/lib/handlebars/source.rb
+++ b/lib/handlebars/source.rb
@@ -1,0 +1,11 @@
+module Handlebars
+  module Source
+    def self.bundled_path
+      File.expand_path("../../../dist/handlebars.js", __FILE__)
+    end
+
+    def self.runtime_bundled_path
+      File.expand_path("../../../dist/handlebars.runtime.js", __FILE__)
+    end
+  end
+end


### PR DESCRIPTION
Added a .gemspec for a lightweight wrapper around specific versions of Handlebars.js. This'll go a long way toward resolving the ruby-js dependencies between HB precompilation libraries. 

```
require 'handlebars/source'
File.read Handlebars::Source.bundled_path
File.read Handlebars::Source.runtime_bundled_path
```
