### PR TITLE
Fix required for 458, paths that begin with './'

### DIFF
--- a/src/handlebars.l
+++ b/src/handlebars.l
@@ -43,7 +43,7 @@
 <mu>"true"/[}\s]                 { return 'BOOLEAN'; }
 <mu>"false"/[}\s]                { return 'BOOLEAN'; }
 <mu>\-?[0-9]+/[}\s]              { return 'INTEGER'; }
-<mu>[a-zA-Z0-9_$-]+/[=}\s\/.]    { return 'ID'; }
+<mu>[a-zA-Z0-9_$:-]+/[=}\s\/.]   { return 'ID'; }
 <mu>'['[^\]]*']'                 { yytext = yytext.substr(1, yyleng-2); return 'ID'; }
 <mu>.                            { return 'INVALID'; }
 <par>\s+                         { /*ignore whitespace*/ }


### PR DESCRIPTION
avoid name collisions with registered helper functions.

Issue #458
