### PR TITLE
merge helpers in compiled template

### DIFF
--- a/lib/handlebars/compiler/compiler.js
+++ b/lib/handlebars/compiler/compiler.js
@@ -496,7 +496,12 @@ JavaScriptCompiler.prototype = {
 
     if (!this.isChild) {
       var namespace = this.namespace;
-      var copies = "helpers = helpers || " + namespace + ".helpers;";
+      var copies = [
+        "helpers = helpers || {}",
+        "for (var key in " + namespace + ".helpers) {",
+        "  helpers[key] = helpers[key] || " + namespace + ".helpers[key];",
+        "}"
+      ].join('\n');
       if (this.environment.usePartial) { copies = copies + " partials = partials || " + namespace + ".partials;"; }
       if (this.options.data) { copies = copies + " data = data || {};"; }
       out.push(copies);


### PR DESCRIPTION
The compiled template handle helpers:

``` js
helpers = helpers || Handlebars.helpers;
```

This patch will merge the helpers:

``` js
helpers = helpers || {};
for (var key in Handlebars.helpers) {
  helpers[key] = helpers[key] || Handlebars.helpers[key];
}
```
