### PR TITLE
Amd module return values

### DIFF
--- a/bin/handlebars
+++ b/bin/handlebars
@@ -184,6 +184,13 @@ argv._.forEach(function(template) {
 // Output the content
 if (!argv.simple) {
   if (argv.amd) {
+    if(argv._.length > 1){
+      if(argv.partial){
+        output.push('return Handlebars.partials;\n');
+      } else {
+        output.push('return templates;\n');
+      }
+    }
     output.push('});');
   } else if (!argv.commonjs) {
     output.push('})();');


### PR DESCRIPTION
This is a rewrite of pull request #377 

If building AMD module output and only one template/partial, return that compiled template as the module output. If building AMD module output and multiple templates/partials return the full hash of templates/partials.
