### PR TITLE
Enable dist files to work with CommonJS

### DIFF
--- a/dist/handlebars.js
+++ b/dist/handlebars.js
@@ -25,6 +25,10 @@ THE SOFTWARE.
 // lib/handlebars/browser-prefix.js
 var Handlebars = {};
 
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = Handlebars;
+}
+
 (function(Handlebars, undefined) {
 ;
 // lib/handlebars/base.js

--- a/dist/handlebars.runtime.js
+++ b/dist/handlebars.runtime.js
@@ -25,6 +25,10 @@ THE SOFTWARE.
 // lib/handlebars/browser-prefix.js
 var Handlebars = {};
 
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = Handlebars;
+}
+
 (function(Handlebars, undefined) {
 ;
 // lib/handlebars/base.js

--- a/lib/handlebars/browser-prefix.js
+++ b/lib/handlebars/browser-prefix.js
@@ -1,3 +1,7 @@
 var Handlebars = {};
 
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = Handlebars;
+}
+
 (function(Handlebars, undefined) {


### PR DESCRIPTION
These three simple lines enable the client-side `dist` files to work with a CommonJS library like Stitch or Browserify.  With a little trick in bundling, you can now do this in the browser:

``` js
var Handlebars = require('handlebars');
```

This becomes increasingly important for tools like [Rendr](https://github.com/airbnb/rendr) that allow running code isomorphically on the client and server.
