### PR TITLE
Enable dist files to work with CommonJS AND amd-style/require.js

### DIFF
--- a/dist/handlebars.js
+++ b/dist/handlebars.js
@@ -23,7 +23,7 @@ THE SOFTWARE.
 */
 
 // lib/handlebars/browser-prefix.js
-(function(module, undefined) {
+(function(undefined) {
 
 var Handlebars = {};
 
@@ -2247,5 +2247,5 @@ if (typeof window === 'object') { window.Handlebars = Handlebars; } else
 // node.js
 if (typeof global === 'object') { global.Handlebars = Handlebars; }
 
-})(module)
+})()
 ;

--- a/lib/handlebars/browser-prefix.js
+++ b/lib/handlebars/browser-prefix.js
@@ -1,3 +1,3 @@
-(function(module, undefined) {
+(function(undefined) {
 
 var Handlebars = {};

--- a/lib/handlebars/browser-suffix.js
+++ b/lib/handlebars/browser-suffix.js
@@ -10,5 +10,5 @@ if (typeof window === 'object') { window.Handlebars = Handlebars; } else
 // node.js
 if (typeof global === 'object') { global.Handlebars = Handlebars; }
 
-})(module)
+})()
 ;


### PR DESCRIPTION
This PR is a proposition to make _handlebars.js_ even more compatible with library styles. It add's compatibility to the [amd-style (require.js)](http://requirejs.org/) and includes #500 for building compatibility to CommonJS and not polluting global namespace anymore.

…or it might be a sign that _making compatible to_ should find and end somewhere…
