### PR TITLE
Include a .nuspec package file to include handlebars.js on NuGet

### DIFF
--- a/handlebars.js.nuspec
+++ b/handlebars.js.nuspec
@@ -11,4 +11,7 @@
 		<releaseNotes></releaseNotes>
 		<tags>handlebars mustache template html</tags>
 	</metadata>
+	<files>
+		<file src="dist\handlebars.js" target="Content\Scripts" />
+	</files>
 </package>


### PR DESCRIPTION
I thought it might be useful to include handlebars.js on NuGet so I created a nuspec file for the project.

Not sure if it's named or placed in a fashion that would be acceptable for all those involved with the project.

I'd also be happy to push the package to NuGet if need be. Otherwise: http://docs.nuget.org/docs/creating-packages/creating-and-publishing-a-package describes what it would take.
