### PR TITLE
Add AMD support for the browser

### DIFF
--- a/dist/handlebars.js
+++ b/dist/handlebars.js
@@ -23,9 +23,16 @@ THE SOFTWARE.
 */
 
 // lib/handlebars/browser-prefix.js
-var Handlebars = {};
-
-(function(Handlebars, undefined) {
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(factory);
+  } else {
+    // Browser globals
+    root.Handlebars = factory();
+  }
+}(this, function (undefined) {
+	var Handlebars = {};
 ;
 // lib/handlebars/base.js
 
@@ -2196,5 +2203,6 @@ Handlebars.VM = {
 Handlebars.template = Handlebars.VM.template;
 ;
 // lib/handlebars/browser-suffix.js
-})(Handlebars);
+  return Handlebars;
+}));
 ;

--- a/dist/handlebars.runtime.js
+++ b/dist/handlebars.runtime.js
@@ -23,9 +23,16 @@ THE SOFTWARE.
 */
 
 // lib/handlebars/browser-prefix.js
-var Handlebars = {};
-
-(function(Handlebars, undefined) {
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(factory);
+  } else {
+    // Browser globals
+    root.Handlebars = factory();
+  }
+}(this, function (undefined) {
+	var Handlebars = {};
 ;
 // lib/handlebars/base.js
 
@@ -312,5 +319,6 @@ Handlebars.VM = {
 Handlebars.template = Handlebars.VM.template;
 ;
 // lib/handlebars/browser-suffix.js
-})(Handlebars);
+  return Handlebars;
+}));
 ;

--- a/lib/handlebars/browser-prefix.js
+++ b/lib/handlebars/browser-prefix.js
@@ -1,3 +1,10 @@
-var Handlebars = {};
-
-(function(Handlebars, undefined) {
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(factory);
+  } else {
+    // Browser globals
+    root.Handlebars = factory();
+  }
+}(this, function (undefined) {
+	var Handlebars = {};

--- a/lib/handlebars/browser-suffix.js
+++ b/lib/handlebars/browser-suffix.js
@@ -1,1 +1,2 @@
-})(Handlebars);
+  return Handlebars;
+}));


### PR DESCRIPTION
The title pretty much says it all. This benefits all the people of the community using AMD while preserving the use of the global variable if no AMD loader is found.
