### PR TITLE
Using handlebars with browserify causes IE to throw - TypeError: Invalid calling object 

### DIFF
--- a/lib/handlebars/utils.js
+++ b/lib/handlebars/utils.js
@@ -1,5 +1,7 @@
 exports.attach = function(Handlebars) {
 
+var toString = Object.prototype.toString;
+
 // BEGIN(BROWSER)
 
 var errorProps = ['description', 'fileName', 'lineNumber', 'message', 'name', 'number', 'stack'];


### PR DESCRIPTION
The isEmpty function in lib/utils uses a cached pointer to Object.prototype.toString.  When a module is browserified, it is wrapped in a closure scope.  In IE, there is a scope conflict which causes the use of the cached toString function pointer to result in

TypeError: Invalid calling object

Adding local cached pointer to Object's toString method resolves the issue.

isEmpty is used in the if helper.  
