### PR TITLE
Use the String(string) form of string coercion

### DIFF
--- a/lib/handlebars/utils.js
+++ b/lib/handlebars/utils.js
@@ -21,7 +21,7 @@ Handlebars.SafeString = function(string) {
   this.string = string;
 };
 Handlebars.SafeString.prototype.toString = function() {
-  return this.string.toString();
+  return "" + this.string;
 };
 
 var escape = {
@@ -60,7 +60,7 @@ Handlebars.Utils = {
     // Force a string conversion as this will be done by the append regardless and
     // the regex test will do this transparently behind the scenes, causing issues if
     // an object's to string has escaped characters in it.
-    string = string.toString();
+    string = "" + string;
 
     if(!possible.test(string)) { return string; }
     return string.replace(badChars, escapeChar);


### PR DESCRIPTION
Using string.toString() will throw errors in current versions of Safari
for some values. The error is a particularly cryptic "Type Error: type
error", which no indication as to the value that caused the error. By
using the String(string) form of coercion the error doesn't seem to
occur.

There is about an inherent performance penalty ranging from 2-42%,
depending on the browser: http://jsperf.com/string-coercion-comparison
