### PR TITLE
Support AMD and CommonJS out of the box

### DIFF
--- a/dist/handlebars.js
+++ b/dist/handlebars.js
@@ -23,9 +23,8 @@ THE SOFTWARE.
 */
 
 // lib/handlebars/browser-prefix.js
-var Handlebars = {};
-
-(function(Handlebars, undefined) {
+(function(undefined) {
+  var Handlebars = {};
 ;
 // lib/handlebars/base.js
 
@@ -2235,5 +2234,17 @@ Handlebars.VM = {
 Handlebars.template = Handlebars.VM.template;
 ;
 // lib/handlebars/browser-suffix.js
-})(Handlebars);
+  if (typeof module === 'object' && module.exports) {
+    // CommonJS
+    module.exports = Handlebars;
+
+  } else if (typeof define === "function" && define.amd) {
+    // AMD modules
+    define(function() { return Handlebars; });
+
+  } else {
+    // other, i.e. browser
+    this.Handlebars = Handlebars;
+  }
+}).call(this);
 ;

--- a/dist/handlebars.runtime.js
+++ b/dist/handlebars.runtime.js
@@ -23,9 +23,8 @@ THE SOFTWARE.
 */
 
 // lib/handlebars/browser-prefix.js
-var Handlebars = {};
-
-(function(Handlebars, undefined) {
+(function(undefined) {
+  var Handlebars = {};
 ;
 // lib/handlebars/base.js
 
@@ -341,5 +340,17 @@ Handlebars.VM = {
 Handlebars.template = Handlebars.VM.template;
 ;
 // lib/handlebars/browser-suffix.js
-})(Handlebars);
+  if (typeof module === 'object' && module.exports) {
+    // CommonJS
+    module.exports = Handlebars;
+
+  } else if (typeof define === "function" && define.amd) {
+    // AMD modules
+    define(function() { return Handlebars; });
+
+  } else {
+    // other, i.e. browser
+    this.Handlebars = Handlebars;
+  }
+}).call(this);
 ;

--- a/lib/handlebars/browser-prefix.js
+++ b/lib/handlebars/browser-prefix.js
@@ -1,3 +1,2 @@
-var Handlebars = {};
-
-(function(Handlebars, undefined) {
+(function(undefined) {
+  var Handlebars = {};

--- a/lib/handlebars/browser-suffix.js
+++ b/lib/handlebars/browser-suffix.js
@@ -1,1 +1,13 @@
-})(Handlebars);
+  if (typeof module === 'object' && module.exports) {
+    // CommonJS
+    module.exports = Handlebars;
+
+  } else if (typeof define === "function" && define.amd) {
+    // AMD modules
+    define(function() { return Handlebars; });
+
+  } else {
+    // other, i.e. browser
+    this.Handlebars = Handlebars;
+  }
+}).call(this);


### PR DESCRIPTION
This add support for both AMD and CommonJS, falling back to typical browser behavior. This is very similar to https://github.com/wycats/handlebars.js/pull/501, but a bit cleaner.  This also obviates https://github.com/wycats/handlebars.js/pull/500 and https://github.com/wycats/handlebars.js/pull/509.

It would be awesome to support these module loaders out of the box, preventing developers from using forks to support their projects (as I have had to do).  Browserify does enable the use of Handlebars + CommonJS in the client side, but only with a fancy AST-walk in a build step; it makes sense to allow CommonJS without a fancy build step.

Specs are passing:

```
Finished in 0.24254 seconds
202 examples, 0 failures

> handlebars@1.0.11 test /Users/spike/code/spikebrehm/handlebars.js
> node_modules/.bin/mocha -u qunit spec/qunit_spec.js


  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․

  134 tests complete (121 ms)
```
