### PR TITLE
More robust global export

### DIFF
--- a/lib/handlebars/browser-prefix.js
+++ b/lib/handlebars/browser-prefix.js
@@ -1,3 +1,2 @@
-var Handlebars = {};
-
-(function(Handlebars, undefined) {
+(function(undefined) {
+    var Handlebars = this.Handlebars = {};

--- a/lib/handlebars/browser-suffix.js
+++ b/lib/handlebars/browser-suffix.js
@@ -1,1 +1,1 @@
-})(Handlebars);
+}.call(this));


### PR DESCRIPTION
Change the method used for exporting the Handlebars global because if
we're wrapped in an IIFE, it's no longer properly exported.  fixes #539

I've done some smoke tests on an already built version of Handlebars and
this should work fine, but I can't for the life of me get Handlebars to
build/test on my Windows environment, so I'd appreciate if someone could
run the test suite on this.
