### PR TITLE
Added BOM removal flag.

### DIFF
--- a/bin/handlebars
+++ b/bin/handlebars
@@ -70,6 +70,11 @@ var optimist = require('optimist')
         'description': 'Template extension.',
         'alias': 'extension',
         'default': 'handlebars'
+      },
+      'b': {
+        'type': 'boolean',
+        'description': 'Removes the BOM (Byte Order Mark) from the beginning of the templates.',
+        'alias': 'bom'
       }
     })
 
@@ -147,6 +152,10 @@ function processTemplate(template, root) {
     });
   } else {
     var data = fs.readFileSync(path, 'utf8');
+    
+    if (argv.bom && data.indexOf('\uFEFF') === 0) {
+      data = data.substring(1);
+    }
 
     var options = {
       knownHelpers: known,


### PR DESCRIPTION
Byte order mark is now removed from the beginning of the files when the 'b' or 'bom'
flag is used.

I needed this option because Visual Studio was adding a BOM to the file and it took me some time to figure out that this was adding the white space to the precompiled templates. I found the same issue mentioned in #508.
