### PR TITLE
`\\{{foo}}` escaping only works in some situations

### DIFF
--- a/spec/basic.js
+++ b/spec/basic.js
@@ -11,7 +11,9 @@ describe("basic context", function() {
 
   it("escaping", function() {
     shouldCompileTo("\\{{foo}}", { foo: "food" }, "{{foo}}");
+    shouldCompileTo("content \\{{foo}}", { foo: "food" }, "content {{foo}}");
     shouldCompileTo("\\\\{{foo}}", { foo: "food" }, "\\food");
+    shouldCompileTo("content \\\\{{foo}}", { foo: "food" }, "content \\food");
     shouldCompileTo("\\\\ {{foo}}", { foo: "food" }, "\\\\ food");
   });
 

--- a/spec/tokenizer.js
+++ b/spec/tokenizer.js
@@ -58,6 +58,7 @@ describe('Tokenizer', function() {
     var result = tokenize("{{foo}} \\{{bar}} {{baz}}");
     result.should.match_tokens(['OPEN', 'ID', 'CLOSE', 'CONTENT', 'CONTENT', 'OPEN', 'ID', 'CLOSE']);
 
+    result[3].should.be_token("CONTENT", " ");
     result[4].should.be_token("CONTENT", "{{bar}} ");
   });
 
@@ -75,6 +76,43 @@ describe('Tokenizer', function() {
     result.should.match_tokens(['OPEN', 'ID', 'CLOSE', 'CONTENT', 'CONTENT', 'OPEN', 'ID', 'CLOSE']);
 
     result[4].should.be_token("CONTENT", "{{{bar}}} ");
+  });
+
+  it('supports escaping escape character', function() {
+    var result = tokenize("{{foo}} \\\\{{bar}} {{baz}}");
+    result.should.match_tokens(['OPEN', 'ID', 'CLOSE', 'CONTENT', 'OPEN', 'ID', 'CLOSE', 'CONTENT', 'OPEN', 'ID', 'CLOSE']);
+
+    result[3].should.be_token("CONTENT", " \\");
+    result[5].should.be_token("ID", "bar");
+  });
+
+  it('supports escaping multiple escape characters', function() {
+    var result = tokenize("{{foo}} \\\\{{bar}} \\\\{{baz}}");
+      result.should.match_tokens(['OPEN', 'ID', 'CLOSE', 'CONTENT', 'OPEN', 'ID', 'CLOSE', 'CONTENT', 'OPEN', 'ID', 'CLOSE']);
+
+      result[3].should.be_token("CONTENT", " \\");
+      result[5].should.be_token("ID", "bar");
+      result[7].should.be_token("CONTENT", " \\");
+      result[9].should.be_token("ID", "baz");
+  });
+
+  it('supports mixed escaped delimiters and escaped escape characters', function() {
+    var result = tokenize("{{foo}} \\\\{{bar}} \\{{baz}}");
+    result.should.match_tokens(['OPEN', 'ID', 'CLOSE', 'CONTENT', 'OPEN', 'ID', 'CLOSE', 'CONTENT', 'CONTENT', 'CONTENT']);
+
+    result[3].should.be_token("CONTENT", " \\");
+    result[4].should.be_token("OPEN", "{{");
+    result[5].should.be_token("ID", "bar");
+    result[7].should.be_token("CONTENT", " ");
+    result[8].should.be_token("CONTENT", "{{baz}}");
+  });
+
+  it('supports escaped escape character on a triple stash', function() {
+    var result = tokenize("{{foo}} \\\\{{{bar}}} {{baz}}");
+    result.should.match_tokens(['OPEN', 'ID', 'CLOSE', 'CONTENT', 'OPEN_UNESCAPED', 'ID', 'CLOSE_UNESCAPED', 'CONTENT', 'OPEN', 'ID', 'CLOSE']);
+
+    result[3].should.be_token("CONTENT", " \\");
+    result[5].should.be_token("ID", "bar");
   });
 
   it('tokenizes a simple path', function() {

--- a/src/handlebars.l
+++ b/src/handlebars.l
@@ -23,10 +23,16 @@ ID    [^\s!"#%-,\.\/;->@\[-\^`\{-~]+/[=}\s\/.]
 
 %%
 
-"\\\\"/("{{")                    yytext = "\\"; return 'CONTENT';
 [^\x00]*?/("{{")                 {
-                                   if(yytext.slice(-1) !== "\\") this.begin("mu");
-                                   if(yytext.slice(-1) === "\\") strip(0,1), this.begin("emu");
+                                   if(yytext.slice(-2) === "\\\\") {
+                                     strip(0,1);
+                                     this.begin("mu");
+                                   } else if(yytext.slice(-1) === "\\") {
+                                     strip(0,1);
+                                     this.begin("emu");
+                                   } else {
+                                     this.begin("mu");
+                                   }
                                    if(yytext) return 'CONTENT';
                                  }
 


### PR DESCRIPTION
Stumbled on this porting the [`\\` escape](https://github.com/wycats/handlebars.js/commit/9e4b59e815b1f557c31fe5abc36b9be8aa0cf34a#src/handlebars.l) to [Jetbrains Handlebars support](https://github.com/JetBrains/intellij-plugins/tree/master/handlebars)...

Currently, `\\{{foo}}` only results in the desired `\fooValue` if it is at the beginning of the file or immediately after a close stache (or in terms of the lexer definition, these are only properly lexed if we enter the initial state with no unlexed characters before `\\`). So, with the existing code, the following test would fail:

``` javascript
shouldCompileTo("content \\\\{{foo}}", { foo: "food" }, "content \\food");
```

This pull updates the lexer to properly tokenize this in all situations, and in service of that refactors the lexing around both the `\` and `\\` escape cases.

Hope this helps, and as always: thanks for all the work you guys do.
