### PR TITLE
New Helper: ifTest. Allow's for javascript expression evaluation.

### DIFF
--- a/lib/handlebars/base.js
+++ b/lib/handlebars/base.js
@@ -144,6 +144,37 @@ Handlebars.registerHelper('if', function(conditional, options) {
   }
 });
 
+Handlebars.registerHelper('ifTest', function(expression, options) {
+
+var evalStr = '',
+    context = [options.data, options.hash];
+
+  if(Object.prototype.toString.call(this) == '[object Object]') {
+    context.push(this);
+  } else {
+    context.push({ that: this });
+  }
+
+  for(var x = 0; x < context.length; x++) {
+    for(var key in context[x]) {
+      evalStr += 'var ' + key + '=' + JSON.stringify(context[x][key]) + ';';
+    }
+  }
+
+  evalStr += expression.replace(/@/g, '').replace(/this/g, 'that');
+
+  try {
+    if(!eval(evalStr)) {
+      return options.inverse(this);
+    } else {
+      return options.fn(this);
+    }
+  } catch(e) {
+    console.error(e + "\n\nThe variable may be outside of this context. Did you forget to add it to the hash? i.e. {{#ifTest 'obj > 1' obj=../obj}}");
+  }
+
+});
+
 Handlebars.registerHelper('unless', function(conditional, options) {
   return Handlebars.helpers['if'].call(this, conditional, {fn: options.inverse, inverse: options.fn});
 });


### PR DESCRIPTION
http://jsfiddle.net/YsteK/

Consider the following context:
var context = { foo: "bar", baz: [ "qux", "quux" ] };

{{#ifTest 'foo == "bar"'}}
    Foobar!
{{/ifTest}}

Result: Foobar!
## 

{{#ifTest 'foo != "bar"'}}
    Not Foobar!
{{else}}
    Foobar!
{{/ifTest}}

Result: Foobar!
## 

{{#each baz}}
    {{#ifTest 'this == "qux"'}} baz contains a qux! {{/ifTest}}
{{/each}}

Result: baz contains a qux!
## 

{{#with baz}}
    {{#ifTest 'this.length > 0'}}
        The length is greater than 0!
    {{/ifTest}}
{{/with}}

Result: The length is greater than 0!
## 

{{#each baz}}
    {{#ifTest '@index < baz.length - 1' baz=../baz}}
        {{this}},
    {{else}}
        {{this}}.
    {{/ifTest}}
{{/each}} Yay comma's!

Result: qux, quux. Yay comma's!
