### PR TITLE
Removed if helper

### DIFF
--- a/lib/handlebars/base.js
+++ b/lib/handlebars/base.js
@@ -133,17 +133,6 @@ Handlebars.registerHelper('each', function(context, options) {
   return ret;
 });
 
-Handlebars.registerHelper('if', function(conditional, options) {
-  var type = toString.call(conditional);
-  if(type === functionType) { conditional = conditional.call(this); }
-
-  if(!conditional || Handlebars.Utils.isEmpty(conditional)) {
-    return options.inverse(this);
-  } else {
-    return options.fn(this);
-  }
-});
-
 Handlebars.registerHelper('unless', function(conditional, options) {
   return Handlebars.helpers['if'].call(this, conditional, {fn: options.inverse, inverse: options.fn});
 });


### PR DESCRIPTION
If this is to be a truly logic-less templating framework, we don't need to supply an if block at all. Filing this based on the rejection reason given here: https://github.com/wycats/handlebars.js/pull/566
