### PR TITLE
Raw block helpers

### DIFF
--- a/lib/handlebars/compiler/ast.js
+++ b/lib/handlebars/compiler/ast.js
@@ -37,6 +37,13 @@ Handlebars.AST.PartialNode = function(partialName, context) {
   this.context      = context;
 };
 
+Handlebars.AST.RawBlockNode = function(mustache, content) {
+  this.type = "block";
+  this.mustache = mustache;
+  this.mustache.isHelper = true;
+  this.mustache.params.splice(0, 0, { type: "STRING", "string": content } );
+};
+
 Handlebars.AST.BlockNode = function(mustache, program, inverse, close) {
   if(mustache.id.original !== close.original) {
     throw new Handlebars.Exception(mustache.id.original + " doesn't match " + close.original);

--- a/spec/blocks.js
+++ b/spec/blocks.js
@@ -20,14 +20,6 @@ describe('blocks', function() {
 
     equal(result, "0. goodbye! 1. Goodbye! 2. GOODBYE! cruel world!", "The @index variable is used");
   });
-
-
-  it("raw block", function() {
-    var string   = "{{{{ {{test}} }}}}";
-    var hash = { test: "hello" };
-    shouldCompileTo(string, hash, " {{test}} ",
-                    "raw block ignores blocks");
-  });
   
   it("empty block", function() {
     var string   = "{{#goodbyes}}{{/goodbyes}}cruel {{world}}!";

--- a/spec/helpers.js
+++ b/spec/helpers.js
@@ -9,6 +9,26 @@ describe('helpers', function() {
     shouldCompileTo(string, [hash, helpers], "<a href='/root/goodbye'>Goodbye</a>");
   });
 
+  it("helper for raw block gets raw content", function() {
+    var string   = "{{{{raw}}}} {{test}} {{{{/raw}}}}";
+    var hash = { test: "hello" };
+    var helpers = { raw: function(content) { 
+        return content;
+    } };
+    shouldCompileTo(string, [hash, helpers], " {{test}} ",
+                    "raw block helper gets raw content");
+  });
+  
+  it("helper for raw block gets parameters", function() {
+    var string   = "{{{{raw 1 2 3}}}} {{test}} {{{{/raw}}}}";
+    var hash = { test: "hello" };
+    var helpers = { raw: function(content, a, b, c) { 
+        return content + a + b + c;
+    } };
+    shouldCompileTo(string, [hash, helpers], " {{test}} 123",
+                    "raw block helper gets raw content");
+  });
+  
   it("helper block with complex lookup expression", function() {
     var string = "{{#goodbyes}}{{../name}}{{/goodbyes}}";
     var hash = {name: "Alan"};

--- a/src/handlebars.l
+++ b/src/handlebars.l
@@ -1,5 +1,5 @@
 
-%x mu emu com
+%x mu emu com raw
 
 %%
 
@@ -18,8 +18,13 @@
                                    return 'CONTENT';
                                  }
 
+<raw>"{{{{/"[^\s!"#%-,\.\/;->@\[-\^`\{-~]+/[=}\s\/.]"}}}}" { yytext = yytext.substr(5, yyleng-9); this.popState(); return 'END_RAW_BLOCK'; }
+<raw>[^\x00]*?/("{{{{/")         { return 'CONTENT'; }
+
 <com>[\s\S]*?"--}}"              { yytext = yytext.substr(0, yyleng-4); this.popState(); return 'COMMENT'; }
 
+<mu>"{{{{"                       { return 'OPEN_RAW_BLOCK'; }
+<mu>"}}}}"                       { this.popState(); this.begin('raw'); return 'CLOSE_RAW_BLOCK'; }
 <mu>"{{{{"[^\x00]*"}}}}"         { yytext = yytext.substr(4, yyleng-8); this.popState(); return 'RAW_BLOCK'; }
 <mu>"{{>"                        { return 'OPEN_PARTIAL'; }
 <mu>"{{#"                        { return 'OPEN_BLOCK'; }

--- a/src/handlebars.yy
+++ b/src/handlebars.yy
@@ -21,13 +21,17 @@ statements
   ;
 
 statement
-  : RAW_BLOCK { $$ = new yy.ContentNode($1); }
+  : openRawBlock CONTENT END_RAW_BLOCK { $$ = new yy.RawBlockNode($1, $2); }
   | openInverse program closeBlock { $$ = new yy.BlockNode($1, $2.inverse, $2, $3); }
   | openBlock program closeBlock { $$ = new yy.BlockNode($1, $2, $2.inverse, $3); }
   | mustache { $$ = $1; }
   | partial { $$ = $1; }
   | CONTENT { $$ = new yy.ContentNode($1); }
   | COMMENT { $$ = new yy.CommentNode($1); }
+  ;
+
+openRawBlock
+  : OPEN_RAW_BLOCK inMustache CLOSE_RAW_BLOCK { $$ = new yy.MustacheNode($2[0], $2[1]); }
   ;
 
 openBlock


### PR DESCRIPTION
Adds support for raw block helpers. Example:

{{{{markdown}}}}
In handlebars.js text like **{{name}}** will not be substituted with the value of the variable name.
{{{{/markdown}}}}

Fixes #559
