### PR TITLE
Close issue #597. Fixes the Utils.isEmpty -function

### DIFF
--- a/lib/handlebars/base.js
+++ b/lib/handlebars/base.js
@@ -137,7 +137,7 @@ Handlebars.registerHelper('if', function(conditional, options) {
   var type = toString.call(conditional);
   if(type === functionType) { conditional = conditional.call(this); }
 
-  if(!conditional || Handlebars.Utils.isEmpty(conditional)) {
+  if(Handlebars.Utils.isEmpty(conditional)) {
     return options.inverse(this);
   } else {
     return options.fn(this);

--- a/lib/handlebars/utils.js
+++ b/lib/handlebars/utils.js
@@ -67,14 +67,15 @@ Handlebars.Utils = {
   },
 
   isEmpty: function(value) {
-    if (!value && value !== 0) {
+    if(typeof value === 'undefined' || value === null || value === false || value === ""){
       return true;
     } else if(toString.call(value) === "[object Array]" && value.length === 0) {
       return true;
     } else {
-      return false;
+        return false;
     }
   }
+
 };
 
 // END(BROWSER)


### PR DESCRIPTION
Close issue #597. Fixes the Utils.isEmpty -function to omit 0 (zero) from falsy values. The if-helper has to only call this function, not do own check for the conditional.
