### PR TITLE
Fix #597. If-helper doesn't anymore consider 0 as falsy value.

### DIFF
--- a/lib/handlebars/base.js
+++ b/lib/handlebars/base.js
@@ -137,7 +137,7 @@ Handlebars.registerHelper('if', function(conditional, options) {
   var type = toString.call(conditional);
   if(type === functionType) { conditional = conditional.call(this); }
 
-  if(!conditional || Handlebars.Utils.isEmpty(conditional)) {
+  if(Handlebars.Utils.isEmpty(conditional)) {
     return options.inverse(this);
   } else {
     return options.fn(this);


### PR DESCRIPTION
Utils.isEmpty doesn't consider 0 as a falsy value, but !conditional -check in if-helper considered it was falsy.
