### PR TITLE
Commonjs precompilation lacked module.exports definition

### DIFF
--- a/bin/handlebars
+++ b/bin/handlebars
@@ -129,7 +129,7 @@ if (!argv.simple) {
   if (argv.amd) {
     output.push('define([\'' + argv.handlebarPath + 'handlebars\'], function(Handlebars) {\n');
   } else if (argv.commonjs) {
-    output.push('var Handlebars = require("' + argv.commonjs + '");');
+    output.push('var Handlebars = require("' + argv.commonjs + '");\n');
   } else {
     output.push('(function() {\n');
   }
@@ -206,7 +206,9 @@ if (!argv.simple) {
     }
     output.push('});');
   } else if (argv.commonjs) {
-    output.push('module.exports = templates;');
+    output.push('\nmodule.exports = function (template) {\n');
+    output.push('  return templates[template];\n');
+    output.push('}');
   } else {
     output.push('})();');
   }


### PR DESCRIPTION
This patch fixes the lack of an export when using Commonjs precompiled templates. Relates to this [Pull Request](https://github.com/wycats/handlebars.js/issues/371)
