### PR TITLE
Remove generated parser.js as part of clean task.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,7 +15,7 @@ module.exports = function(grunt) {
       ]
     },
 
-    clean: ["dist"],
+    clean: ["dist", "lib/handlebars/compiler/parser.js"],
     transpile: {
       amd: {
         type: "amd",


### PR DESCRIPTION
I had a repo that hadn't been updated since the new ES6 modules went it, so when I pulled the new changes and did `grunt clean; grunt amd` I got an old parser.js in my build that used `module.exports`.
