### PR TITLE
Fix "\\{{" immediately following "\{{"

### DIFF
--- a/spec/tokenizer.js
+++ b/spec/tokenizer.js
@@ -88,15 +88,15 @@ describe('Tokenizer', function() {
 
   it('supports escaping multiple escape characters', function() {
     var result = tokenize("{{foo}} \\\\{{bar}} \\\\{{baz}}");
-      result.should.match_tokens(['OPEN', 'ID', 'CLOSE', 'CONTENT', 'OPEN', 'ID', 'CLOSE', 'CONTENT', 'OPEN', 'ID', 'CLOSE']);
+    result.should.match_tokens(['OPEN', 'ID', 'CLOSE', 'CONTENT', 'OPEN', 'ID', 'CLOSE', 'CONTENT', 'OPEN', 'ID', 'CLOSE']);
 
-      result[3].should.be_token("CONTENT", " \\");
-      result[5].should.be_token("ID", "bar");
-      result[7].should.be_token("CONTENT", " \\");
-      result[9].should.be_token("ID", "baz");
+    result[3].should.be_token("CONTENT", " \\");
+    result[5].should.be_token("ID", "bar");
+    result[7].should.be_token("CONTENT", " \\");
+    result[9].should.be_token("ID", "baz");
   });
 
-  it('supports mixed escaped delimiters and escaped escape characters', function() {
+  it('supports escaped mustaches after escaped escape characters', function() {
     var result = tokenize("{{foo}} \\\\{{bar}} \\{{baz}}");
     result.should.match_tokens(['OPEN', 'ID', 'CLOSE', 'CONTENT', 'OPEN', 'ID', 'CLOSE', 'CONTENT', 'CONTENT', 'CONTENT']);
 
@@ -105,6 +105,16 @@ describe('Tokenizer', function() {
     result[5].should.be_token("ID", "bar");
     result[7].should.be_token("CONTENT", " ");
     result[8].should.be_token("CONTENT", "{{baz}}");
+  });
+
+  it('supports escaped escape characters after escaped mustaches', function() {
+    var result = tokenize("{{foo}} \\{{bar}} \\\\{{baz}}");
+    result.should.match_tokens(['OPEN', 'ID', 'CLOSE', 'CONTENT', 'CONTENT', 'CONTENT', 'OPEN', 'ID', 'CLOSE']);
+
+    result[4].should.be_token("CONTENT", "{{bar}} ");
+    result[5].should.be_token("CONTENT", "\\");
+    result[6].should.be_token("OPEN", "{{");
+    result[7].should.be_token("ID", "baz");
   });
 
   it('supports escaped escape character on a triple stash', function() {

--- a/src/handlebars.l
+++ b/src/handlebars.l
@@ -43,9 +43,9 @@ ID    [^\s!"#%-,\.\/;->@\[-\^`\{-~]+/{LOOKAHEAD}
 
 [^\x00]+                         return 'CONTENT';
 
-<emu>[^\x00]{2,}?/("{{"|<<EOF>>) {
-                                   if(yytext.slice(-1) !== "\\") this.popState();
-                                   if(yytext.slice(-1) === "\\") strip(0,1);
+// marks CONTENT up to the next mustache or escaped mustache
+<emu>[^\x00]{2,}?/("{{"|"\\{{"|"\\\\{{"|<<EOF>>) {
+                                   this.popState();
                                    return 'CONTENT';
                                  }
 


### PR DESCRIPTION
Escaped-escape mustaches ("\{{") immediately following escaped mustaches ("{{") were being handled incorrectly.

For example, with context `{foo: 'what'}`, template `\{{foo}} \\{{foo}}` was being rendered as `{{foo}} \{{foo}}`, as opposed to the desired `{{foo}} \what`. 

This fixes the lookahead to make sure yytext still contains the appropriate slashes when we pop out of <emu> so they can be handled consistently by the initial state.
