### PR TITLE
Handlebars is MIT-licensed

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/wycats/handlebars.js.git"
   },
   "author": "Yehuda Katz",
-  "license": "BSD",
+  "license": "MIT",
   "readmeFilename": "README.md",
   "engines": {
     "node": ">=0.4.7"


### PR DESCRIPTION
The package.json list Handlebars as having a BSD license, but the readme says it's MIT licensed
