### PR TITLE
Fixes issue where cli compiles non handlebars templates

### DIFF
--- a/bin/handlebars
+++ b/bin/handlebars
@@ -150,9 +150,9 @@ function processTemplate(template, root) {
         processTemplate(path, root || template);
       }
     });
-  } else {
+  } else if (extension.test(path)) {
     var data = fs.readFileSync(path, 'utf8');
-    
+
     if (argv.bom && data.indexOf('\uFEFF') === 0) {
       data = data.substring(1);
     }


### PR DESCRIPTION
When base folder has non-handlebars template files like so 

```
test/
     app.js
     one/
         test.handlebars
    two/
       test.handlebars
```

and then `handlebars test/**` is run the file `app.js` gets included in the output. 

This commit fixes the issue. 
