### PR TITLE
Add @first and @index to #each object iteration

### DIFF
--- a/lib/handlebars/base.js
+++ b/lib/handlebars/base.js
@@ -101,7 +101,11 @@ function registerDefaultHelpers(instance) {
       } else {
         for(var key in context) {
           if(context.hasOwnProperty(key)) {
-            if(data) { data.key = key; }
+            if(data) { 
+              data.key = key; 
+              data.index = i;
+              data.first = (i == 0);
+            }
             ret = ret + fn(context[key], {data: data});
             i++;
           }


### PR DESCRIPTION
Give users the index for properties. When I am rendering a radio button I use key-value pairs, but I can't use either as unique identifiers because they likely contain invalid identifier characters. I added "first" as an index as well, but have no particular use case for first. Since there is no way to detect "last", I didn't add that property.
