### PR TITLE
Added support for {{helper(syntax, "with", "parentheses", and="commas")}}

### DIFF
--- a/src/handlebars.l
+++ b/src/handlebars.l
@@ -12,7 +12,7 @@ function strip(start, end) {
 LEFT_STRIP    "~"
 RIGHT_STRIP   "~"
 
-LOOKAHEAD           [=~}\s\/.]
+LOOKAHEAD           [=~}\s\/.(),]
 LITERAL_LOOKAHEAD   [~}\s]
 
 /*
@@ -63,6 +63,9 @@ ID    [^\s!"#%-,\.\/;->@\[-\^`\{-~]+/{LOOKAHEAD}
 <mu>"{{"{LEFT_STRIP}?            return 'OPEN';
 
 <mu>"="                          return 'EQUALS';
+<mu>"("                          return 'OPEN_PARENTHESIS';
+<mu>")"                          return 'CLOSE_PARENTHESIS';
+<mu>","                          return 'COMMA';
 <mu>".."                         return 'ID';
 <mu>"."/{LOOKAHEAD}              return 'ID';
 <mu>[\/.]                        return 'SEP';

--- a/src/handlebars.yy
+++ b/src/handlebars.yy
@@ -73,6 +73,9 @@ simpleInverse
 
 inMustache
   : path param* hash? -> [[$1].concat($2), $3]
+  | path OPEN_PARENTHESIS commaSeparatedParams CLOSE_PARENTHESIS -> [[$1].concat($3), null]
+  | path OPEN_PARENTHESIS commaSeparatedParams COMMA commaSeparatedHashes CLOSE_PARENTHESIS -> [[$1].concat($3), new yy.HashNode($5)]
+  | path OPEN_PARENTHESIS commaSeparatedHashes CLOSE_PARENTHESIS -> [[$1], new yy.HashNode($3)]
   | dataName -> [[$1], null]
   ;
 
@@ -84,12 +87,22 @@ param
   | dataName -> $1
   ;
 
+commaSeparatedParams
+  : param -> [$1]
+  | commaSeparatedParams COMMA param -> $1.concat([$3])
+  ;
+
 hash
   : hashSegment+ -> new yy.HashNode($1)
   ;
 
 hashSegment
   : ID EQUALS param -> [$1, $3]
+  ;
+
+commaSeparatedHashes
+  : hashSegment -> [$1]
+  | commaSeparatedHashes COMMA hashSegment -> $1.concat([$3])
   ;
 
 partialName


### PR DESCRIPTION
At the company I work for, we use some other (PHP) templating systems with slightly different syntax for helpers, e.g.

```
{{helper(syntax, "with", "parentheses")}}
```

We've build some tools and workflows around this, depending on this syntax (e.g. non-tech savvy translators are used to this). We want to start using handlebars.js, but the parentheses/comma-less syntax of helpers is kind of deal breaker for the translators.

The commit(s) related to this pull request extend the grammar of the handlebars templates to support the syntax

```
{{helper(syntax, "with", "parentheses", and="commas")}}
```

Would there be any interest to include this syntax extension in the official handlebars.js library?
Or are we condemned to maintain or own fork? :)
