### PR TITLE
Issue 665: pin es6-module-transpiler at 0.3.3 with npm-shrinkwrap

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,580 @@
+{
+  "name": "handlebars",
+  "version": "1.1.2",
+  "dependencies": {
+    "optimist": {
+      "version": "0.3.7",
+      "from": "optimist@~0.3",
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.2",
+          "from": "wordwrap@~0.0.2"
+        }
+      }
+    },
+    "uglify-js": {
+      "version": "2.3.6",
+      "from": "uglify-js@~2.3",
+      "dependencies": {
+        "source-map": {
+          "version": "0.1.31",
+          "from": "source-map@~0.1.7",
+          "dependencies": {
+            "amdefine": {
+              "version": "0.1.0",
+              "from": "amdefine@>=0.0.4"
+            }
+          }
+        }
+      }
+    },
+    "async": {
+      "version": "0.2.9",
+      "from": "async@~0.2.9"
+    },
+    "benchmark": {
+      "version": "1.0.0",
+      "from": "benchmark@~1.0"
+    },
+    "dustjs-linkedin": {
+      "version": "2.0.3",
+      "from": "dustjs-linkedin@~2.0.2"
+    },
+    "grunt-contrib-clean": {
+      "version": "0.4.1",
+      "from": "grunt-contrib-clean@~0.4.1"
+    },
+    "grunt-contrib-copy": {
+      "version": "0.4.1",
+      "from": "grunt-contrib-copy@~0.4.1"
+    },
+    "mustache": {
+      "version": "0.7.3",
+      "from": "mustache@~0.7.2"
+    },
+    "semver": {
+      "version": "2.1.0",
+      "from": "semver@~2.1.0"
+    },
+    "should": {
+      "version": "1.2.2",
+      "from": "should@~1.2.2"
+    },
+    "underscore": {
+      "version": "1.5.2",
+      "from": "underscore@~1.5.1"
+    },
+    "eco": {
+      "version": "1.1.0-rc-3",
+      "from": "eco@~1.1.0-rc-3",
+      "dependencies": {
+        "strscan": {
+          "version": "1.0.1",
+          "from": "strscan@>=1.0.1"
+        },
+        "coffee-script": {
+          "version": "1.6.3",
+          "from": "coffee-script@>=1.2.0"
+        }
+      }
+    },
+    "grunt-contrib-requirejs": {
+      "version": "0.4.1",
+      "from": "grunt-contrib-requirejs@~0.4.1",
+      "dependencies": {
+        "requirejs": {
+          "version": "2.1.9",
+          "from": "requirejs@~2.1.0"
+        }
+      }
+    },
+    "jison": {
+      "version": "0.3.12",
+      "from": "jison@~0.3.0",
+      "dependencies": {
+        "JSONSelect": {
+          "version": "0.4.0",
+          "from": "JSONSelect@0.4.0"
+        },
+        "reflect": {
+          "version": "0.0.7",
+          "from": "reflect@0.0.7"
+        },
+        "nomnom": {
+          "version": "0.4.3",
+          "from": "nomnom@0.4.3"
+        }
+      }
+    },
+    "aws-sdk": {
+      "version": "1.5.2",
+      "from": "aws-sdk@~1.5.0",
+      "dependencies": {
+        "xml2js": {
+          "version": "0.2.4",
+          "from": "xml2js@0.2.4",
+          "dependencies": {
+            "sax": {
+              "version": "0.5.5",
+              "from": "sax@>=0.4.2"
+            }
+          }
+        },
+        "xmlbuilder": {
+          "version": "1.0.0",
+          "from": "xmlbuilder@latest",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-1.0.0.tgz"
+        }
+      }
+    },
+    "grunt-es6-module-transpiler": {
+      "version": "0.5.1",
+      "from": "git://github.com/joefiorini/grunt-es6-module-transpiler",
+      "resolved": "git://github.com/joefiorini/grunt-es6-module-transpiler#22e3018458df5297384ed8b69577d5f405a41d21",
+      "dependencies": {
+        "es6-module-transpiler": {
+          "version": "0.3.3",
+          "from": "es6-module-transpiler@~0.3",
+          "dependencies": {
+            "through": {
+              "version": "2.3.4",
+              "from": "through@~2.3.4"
+            }
+          }
+        }
+      }
+    },
+    "keen.io": {
+      "version": "0.0.3",
+      "from": "keen.io@0.0.3",
+      "dependencies": {
+        "superagent": {
+          "version": "0.13.0",
+          "from": "superagent@~0.13.0",
+          "dependencies": {
+            "qs": {
+              "version": "0.5.2",
+              "from": "qs@0.5.2"
+            },
+            "formidable": {
+              "version": "1.0.9",
+              "from": "formidable@1.0.9"
+            },
+            "mime": {
+              "version": "1.2.5",
+              "from": "mime@1.2.5"
+            },
+            "emitter-component": {
+              "version": "0.0.6",
+              "from": "emitter-component@0.0.6"
+            },
+            "methods": {
+              "version": "0.0.1",
+              "from": "methods@0.0.1"
+            },
+            "cookiejar": {
+              "version": "1.3.0",
+              "from": "cookiejar@1.3.0"
+            }
+          }
+        },
+        "underscore": {
+          "version": "1.4.4",
+          "from": "underscore@~1.4.4"
+        }
+      }
+    },
+    "es6-module-packager": {
+      "version": "0.0.3",
+      "from": "es6-module-packager@*",
+      "dependencies": {
+        "es6-module-transpiler": {
+          "version": "0.3.3",
+          "from": "es6-module-transpiler@~0.3.0",
+          "dependencies": {
+            "optimist": {
+              "version": "0.3.7",
+              "from": "optimist@~0.3.5",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "from": "wordwrap@~0.0.2"
+                }
+              }
+            },
+            "through": {
+              "version": "2.3.4",
+              "from": "through@~2.3.4"
+            }
+          }
+        },
+        "optimist": {
+          "version": "0.6.0",
+          "from": "optimist@~0.6.0",
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.2",
+              "from": "wordwrap@~0.0.2"
+            },
+            "minimist": {
+              "version": "0.0.5",
+              "from": "minimist@~0.0.1"
+            }
+          }
+        }
+      }
+    },
+    "grunt": {
+      "version": "0.4.2",
+      "from": "grunt@~0.4.1",
+      "dependencies": {
+        "async": {
+          "version": "0.1.22",
+          "from": "async@~0.1.22"
+        },
+        "coffee-script": {
+          "version": "1.3.3",
+          "from": "coffee-script@~1.3.3"
+        },
+        "colors": {
+          "version": "0.6.2",
+          "from": "colors@~0.6.2"
+        },
+        "dateformat": {
+          "version": "1.0.2-1.2.3",
+          "from": "dateformat@1.0.2-1.2.3"
+        },
+        "eventemitter2": {
+          "version": "0.4.13",
+          "from": "eventemitter2@~0.4.13"
+        },
+        "findup-sync": {
+          "version": "0.1.2",
+          "from": "findup-sync@~0.1.2",
+          "dependencies": {
+            "lodash": {
+              "version": "1.0.1",
+              "from": "lodash@~1.0.1"
+            }
+          }
+        },
+        "glob": {
+          "version": "3.1.21",
+          "from": "glob@~3.1.21",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "1.2.3",
+              "from": "graceful-fs@~1.2.0"
+            },
+            "inherits": {
+              "version": "1.0.0",
+              "from": "inherits@1"
+            }
+          }
+        },
+        "hooker": {
+          "version": "0.2.3",
+          "from": "hooker@~0.2.3"
+        },
+        "iconv-lite": {
+          "version": "0.2.11",
+          "from": "iconv-lite@~0.2.11"
+        },
+        "minimatch": {
+          "version": "0.2.12",
+          "from": "minimatch@~0.2.12",
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.5.0",
+              "from": "lru-cache@2"
+            },
+            "sigmund": {
+              "version": "1.0.0",
+              "from": "sigmund@~1.0.0"
+            }
+          }
+        },
+        "nopt": {
+          "version": "1.0.10",
+          "from": "nopt@~1.0.10",
+          "dependencies": {
+            "abbrev": {
+              "version": "1.0.4",
+              "from": "abbrev@1"
+            }
+          }
+        },
+        "rimraf": {
+          "version": "2.0.3",
+          "from": "rimraf@~2.0.3",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "1.1.14",
+              "from": "graceful-fs@~1.1"
+            }
+          }
+        },
+        "lodash": {
+          "version": "0.9.2",
+          "from": "lodash@~0.9.2"
+        },
+        "underscore.string": {
+          "version": "2.2.1",
+          "from": "underscore.string@~2.2.1"
+        },
+        "which": {
+          "version": "1.0.5",
+          "from": "which@~1.0.5"
+        },
+        "js-yaml": {
+          "version": "2.0.5",
+          "from": "js-yaml@~2.0.5",
+          "dependencies": {
+            "argparse": {
+              "version": "0.1.15",
+              "from": "argparse@~ 0.1.11",
+              "dependencies": {
+                "underscore": {
+                  "version": "1.4.4",
+                  "from": "underscore@~1.4.3"
+                },
+                "underscore.string": {
+                  "version": "2.3.3",
+                  "from": "underscore.string@~2.3.1"
+                }
+              }
+            },
+            "esprima": {
+              "version": "1.0.4",
+              "from": "esprima@~ 1.0.2"
+            }
+          }
+        },
+        "exit": {
+          "version": "0.1.2",
+          "from": "exit@~0.1.1"
+        },
+        "getobject": {
+          "version": "0.1.0",
+          "from": "getobject@~0.1.0"
+        }
+      }
+    },
+    "grunt-contrib-uglify": {
+      "version": "0.2.7",
+      "from": "grunt-contrib-uglify@~0.2.2",
+      "dependencies": {
+        "uglify-js": {
+          "version": "2.4.3",
+          "from": "uglify-js@~2.4.0",
+          "dependencies": {
+            "source-map": {
+              "version": "0.1.31",
+              "from": "source-map@~0.1.7",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.0",
+                  "from": "amdefine@>=0.0.4"
+                }
+              }
+            },
+            "uglify-to-browserify": {
+              "version": "1.0.1",
+              "from": "uglify-to-browserify@~1.0.0"
+            }
+          }
+        },
+        "grunt-lib-contrib": {
+          "version": "0.6.1",
+          "from": "grunt-lib-contrib@~0.6.1",
+          "dependencies": {
+            "zlib-browserify": {
+              "version": "0.0.1",
+              "from": "zlib-browserify@0.0.1"
+            }
+          }
+        }
+      }
+    },
+    "mocha": {
+      "version": "1.14.0",
+      "from": "mocha@*",
+      "dependencies": {
+        "commander": {
+          "version": "2.0.0",
+          "from": "commander@2.0.0"
+        },
+        "growl": {
+          "version": "1.7.0",
+          "from": "growl@1.7.x"
+        },
+        "jade": {
+          "version": "0.26.3",
+          "from": "jade@0.26.3",
+          "dependencies": {
+            "commander": {
+              "version": "0.6.1",
+              "from": "commander@0.6.1"
+            },
+            "mkdirp": {
+              "version": "0.3.0",
+              "from": "mkdirp@0.3.0"
+            }
+          }
+        },
+        "diff": {
+          "version": "1.0.7",
+          "from": "diff@1.0.7"
+        },
+        "debug": {
+          "version": "0.7.4",
+          "from": "debug@*"
+        },
+        "mkdirp": {
+          "version": "0.3.5",
+          "from": "mkdirp@0.3.5"
+        },
+        "glob": {
+          "version": "3.2.3",
+          "from": "glob@3.2.3",
+          "dependencies": {
+            "minimatch": {
+              "version": "0.2.12",
+              "from": "minimatch@~0.2.11",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.5.0",
+                  "from": "lru-cache@2"
+                },
+                "sigmund": {
+                  "version": "1.0.0",
+                  "from": "sigmund@~1.0.0"
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "2.0.1",
+              "from": "graceful-fs@~2.0.0"
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@2"
+            }
+          }
+        }
+      }
+    },
+    "grunt-cli": {
+      "version": "0.1.11",
+      "from": "grunt-cli@~0.1.10",
+      "dependencies": {
+        "nopt": {
+          "version": "1.0.10",
+          "from": "nopt@~1.0.10",
+          "dependencies": {
+            "abbrev": {
+              "version": "1.0.4",
+              "from": "abbrev@1"
+            }
+          }
+        },
+        "findup-sync": {
+          "version": "0.1.2",
+          "from": "findup-sync@~0.1.0",
+          "dependencies": {
+            "glob": {
+              "version": "3.1.21",
+              "from": "glob@~3.1.21",
+              "dependencies": {
+                "minimatch": {
+                  "version": "0.2.12",
+                  "from": "minimatch@~0.2.11",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.5.0",
+                      "from": "lru-cache@2"
+                    },
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "from": "sigmund@~1.0.0"
+                    }
+                  }
+                },
+                "graceful-fs": {
+                  "version": "1.2.3",
+                  "from": "graceful-fs@~1.2.0"
+                },
+                "inherits": {
+                  "version": "1.0.0",
+                  "from": "inherits@1"
+                }
+              }
+            },
+            "lodash": {
+              "version": "1.0.1",
+              "from": "lodash@~1.0.1"
+            }
+          }
+        },
+        "resolve": {
+          "version": "0.3.1",
+          "from": "resolve@~0.3.1"
+        }
+      }
+    },
+    "grunt-contrib-jshint": {
+      "version": "0.6.5",
+      "from": "grunt-contrib-jshint@~0.6.3",
+      "dependencies": {
+        "jshint": {
+          "version": "2.1.11",
+          "from": "jshint@~2.1.10",
+          "dependencies": {
+            "shelljs": {
+              "version": "0.1.4",
+              "from": "shelljs@0.1.x"
+            },
+            "underscore": {
+              "version": "1.4.4",
+              "from": "underscore@1.4.x"
+            },
+            "cli": {
+              "version": "0.4.5",
+              "from": "cli@0.4.x",
+              "dependencies": {
+                "glob": {
+                  "version": "3.2.7",
+                  "from": "glob@>= 3.1.4",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@2"
+                    }
+                  }
+                }
+              }
+            },
+            "minimatch": {
+              "version": "0.2.12",
+              "from": "minimatch@0.x.x",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.5.0",
+                  "from": "lru-cache@2"
+                },
+                "sigmund": {
+                  "version": "1.0.0",
+                  "from": "sigmund@~1.0.0"
+                }
+              }
+            },
+            "console-browserify": {
+              "version": "0.1.6",
+              "from": "console-browserify@0.1.x"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Issue #665: handlebars build is broken with es6-module-transpiler v0.3.4
(also see square/es6-module-transpiler#81 and square/es6-module-transpiler#82)

This PR adds npm-shrinkwrap.json, to pin dependecies to desired versions (such as 0.3.3 of es6-module-transpiler),
