### PR TITLE
Update runtime.js

### DIFF
--- a/lib/handlebars/runtime.js
+++ b/lib/handlebars/runtime.js
@@ -41,7 +41,7 @@ export function template(templateSpec, env) {
     };
   } else {
     invokePartialWrapper = function(partial, name /* , context, helpers, partials, data */) {
-      var result = invokePartial.apply(this, arguments);
+      var result = env.VM.invokePartial.apply(this, arguments);
       if (result) { return result; }
       throw new Exception("The partial " + name + " could not be compiled when running in runtime-only mode");
     };


### PR DESCRIPTION
Made template method use the passed in runtime to invoke a partial, rather than the in scope invokePartial method variable so as to allow the implementation to be overridden.
