### PR TITLE
Allow any number of trailing characters for valid JavaScript variable

### DIFF
--- a/lib/handlebars/compiler/javascript-compiler.js
+++ b/lib/handlebars/compiler/javascript-compiler.js
@@ -843,7 +843,7 @@ for(var i=0, l=reservedWords.length; i<l; i++) {
 }
 
 JavaScriptCompiler.isValidJavaScriptVariableName = function(name) {
-  if(!JavaScriptCompiler.RESERVED_WORDS[name] && /^[a-zA-Z_$][0-9a-zA-Z_$]+$/.test(name)) {
+  if(!JavaScriptCompiler.RESERVED_WORDS[name] && /^[a-zA-Z_$][0-9a-zA-Z_$]*$/.test(name)) {
     return true;
   }
   return false;


### PR DESCRIPTION
Surprised it hasn't been mentioned before, but a single character is actually a valid JavaScript variable (and property).
