### PR TITLE
Add dombars to the projects list

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -382,6 +382,7 @@ Handlebars in the Wild
   templating engine, extending it with automatic data binding support.
 * [YUI](http://yuilibrary.com/yui/docs/handlebars/) implements a port of handlebars
 * [Swag](https://github.com/elving/swag) by [@elving](https://github.com/elving) is a growing collection of helpers for handlebars.js. Give your handlebars.js templates some swag son!
+* [DOMBars](https://github.com/blakeembrey/dombars) is a DOM-based templating engine built on the Handlebars parser and runtime
 
 External Resources
 ------------------


### PR DESCRIPTION
I recently completed a stable base release of [dombars](https://github.com/blakeembrey/dombars), which is a DOM-based templating engine built directly on top of the Handlebars engine.
