### PR TITLE
Make the environment reusable

### DIFF
--- a/lib/handlebars.js
+++ b/lib/handlebars.js
@@ -14,7 +14,9 @@ var create = function() {
   hb.compile = function(input, options) {
     return compile(input, options, hb);
   };
-  hb.precompile = precompile;
+  hb.precompile = function (input, options) {
+    return precompile(input, options, hb);
+  };
 
   hb.AST = AST;
   hb.Compiler = Compiler;

--- a/lib/handlebars/compiler/compiler.js
+++ b/lib/handlebars/compiler/compiler.js
@@ -1,7 +1,4 @@
 import Exception from "../exception";
-import { parse } from "./base";
-import JavaScriptCompiler from "./javascript-compiler";
-import AST from "./ast";
 
 export function Compiler() {}
 
@@ -423,8 +420,8 @@ Compiler.prototype = {
   }
 };
 
-export function precompile(input, options) {
-  if (input == null || (typeof input !== 'string' && input.constructor !== AST.ProgramNode)) {
+export function precompile(input, options, env) {
+  if (input == null || (typeof input !== 'string' && input.constructor !== env.AST.ProgramNode)) {
     throw new Exception("You must pass a string or Handlebars AST to Handlebars.precompile. You passed " + input);
   }
 
@@ -433,13 +430,13 @@ export function precompile(input, options) {
     options.data = true;
   }
 
-  var ast = parse(input);
-  var environment = new Compiler().compile(ast, options);
-  return new JavaScriptCompiler().compile(environment, options);
+  var ast = env.parse(input);
+  var environment = new env.Compiler().compile(ast, options);
+  return new env.JavaScriptCompiler().compile(environment, options);
 }
 
 export function compile(input, options, env) {
-  if (input == null || (typeof input !== 'string' && input.constructor !== AST.ProgramNode)) {
+  if (input == null || (typeof input !== 'string' && input.constructor !== env.AST.ProgramNode)) {
     throw new Exception("You must pass a string or Handlebars AST to Handlebars.compile. You passed " + input);
   }
 
@@ -452,9 +449,9 @@ export function compile(input, options, env) {
   var compiled;
 
   function compileInput() {
-    var ast = parse(input);
-    var environment = new Compiler().compile(ast, options);
-    var templateSpec = new JavaScriptCompiler().compile(environment, options, undefined, true);
+    var ast = env.parse(input);
+    var environment = new env.Compiler().compile(ast, options);
+    var templateSpec = new env.JavaScriptCompiler().compile(environment, options, undefined, true);
     return env.template(templateSpec);
   }
 

--- a/spec/env/runtime.js
+++ b/spec/env/runtime.js
@@ -8,11 +8,21 @@ var _ = require('underscore'),
 global.Handlebars = undefined;
 vm.runInThisContext(fs.readFileSync(__dirname + '/../../dist/handlebars.runtime.js'), 'dist/handlebars.runtime.js');
 
+var parse = require('../../dist/cjs/handlebars/compiler/base').parse;
 var compiler = require('../../dist/cjs/handlebars/compiler/compiler');
+var JavaScriptCompiler = require('../../dist/cjs/handlebars/compiler/javascript-compiler')['default'];
 
 global.CompilerContext = {
   compile: function(template, options) {
-    var templateSpec = compiler.precompile(template, options);
+    // Hack the compiler on to the environment for these specific tests
+    handlebarsEnv.precompile = function(template, options) {
+      return compiler.precompile(template, options, handlebarsEnv);
+    };
+    handlebarsEnv.parse = parse;
+    handlebarsEnv.Compiler = compiler.Compiler;
+    handlebarsEnv.JavaScriptCompiler = JavaScriptCompiler;
+
+    var templateSpec = handlebarsEnv.precompile(template, options);
     return handlebarsEnv.template(safeEval(templateSpec));
   },
   compileWithPartial: function(template, options) {
@@ -20,6 +30,10 @@ global.CompilerContext = {
     handlebarsEnv.compile = function(template, options) {
       return compiler.compile(template, options, handlebarsEnv);
     };
+    handlebarsEnv.parse = parse;
+    handlebarsEnv.Compiler = compiler.Compiler;
+    handlebarsEnv.JavaScriptCompiler = JavaScriptCompiler;
+
     return handlebarsEnv.compile(template, options);
   }
 };


### PR DESCRIPTION
Making the environment variable pass in across both `precompile` and `compile` functions allows other modules to easily extend the behaviour without duplicating large chunks of code.
