### PR TITLE
Pull options out from param setup to allow easier extension

### DIFF
--- a/lib/handlebars/compiler/javascript-compiler.js
+++ b/lib/handlebars/compiler/javascript-compiler.js
@@ -798,9 +798,7 @@ JavaScriptCompiler.prototype = {
     };
   },
 
-  // the params and contexts arguments are passed in arrays
-  // to fill in
-  setupParams: function(paramSize, params, useRegister) {
+  setupOptions: function(paramSize, params) {
     var options = [], contexts = [], types = [], param, inverse, program;
 
     options.push("hash:" + this.popStack());
@@ -846,14 +844,21 @@ JavaScriptCompiler.prototype = {
       options.push("data:data");
     }
 
-    options = "{" + options.join(",") + "}";
+    return options;
+  },
+
+  // the params and contexts arguments are passed in arrays
+  // to fill in
+  setupParams: function(paramSize, params, useRegister) {
+    var options = '{' + this.setupOptions(paramSize, params).join(',') + '}';
+
     if (useRegister) {
       this.register('options', options);
       params.push('options');
     } else {
       params.push(options);
     }
-    return params.join(", ");
+    return params.join(', ');
   }
 };
 


### PR DESCRIPTION
At the moment it's impossible to add custom options to pass to helpers unless you override and duplicate the entire `setupParams` method. By pulling just the options hash set up into another function, we can easily override the options hash and push our own options into the object.
