### PR TITLE
Fix for reserved keyword "default"

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,9 +3,9 @@
 
 // var local = handlebars.create();
 
-var handlebars = require('../dist/cjs/handlebars').default;
+var handlebars = require('../dist/cjs/handlebars')["default"];
 
-handlebars.Visitor = require('../dist/cjs/handlebars/compiler/visitor').default;
+handlebars.Visitor = require('../dist/cjs/handlebars/compiler/visitor')["default"];
 
 var printer = require('../dist/cjs/handlebars/compiler/printer');
 handlebars.PrintVisitor = printer.PrintVisitor;


### PR DESCRIPTION
I noticed an issue while using handlebars.js in a Browserify bundle in Internet Explorer 8, and it looks like the problem is caused by the use of a reserved keyword, "default". This commit fixed the problem.
