### PR TITLE
Fix parser generation under window

### DIFF
--- a/tasks/parser.js
+++ b/tasks/parser.js
@@ -4,7 +4,13 @@ module.exports = function(grunt) {
   grunt.registerTask('parser', 'Generate jison parser.', function() {
     var done = this.async();
 
-    var child = childProcess.spawn('./node_modules/.bin/jison', ['-m', 'js', 'src/handlebars.yy', 'src/handlebars.l'], {stdio: 'inherit'});
+    var cmd = './node_modules/.bin/jison';
+
+    if(process.platform === 'win32'){
+        cmd = 'node_modules\\.bin\\jison.cmd';
+    }
+
+    var child = childProcess.spawn(cmd, ['-m', 'js', 'src/handlebars.yy', 'src/handlebars.l'], {stdio: 'inherit'});
     child.on('exit', function(code) {
       if (code != 0) {
         grunt.fatal('Jison failure: ' + code);


### PR DESCRIPTION
Parser task did not execute correctly on windows environments because of forward/backward slash issues.  Fix inspired by the commit in npm-www linked below.  Feels slightly dirty but works on both my windows and mac.  

https://github.com/isaacs/npm-www/commit/98de54b2530e8571fc76a840101d7c897d6e6ba8
