### PR TITLE
JavaScript Compiler Cleanup

### DIFF
--- a/lib/handlebars/base.js
+++ b/lib/handlebars/base.js
@@ -102,8 +102,8 @@ function registerDefaultHelpers(instance) {
       } else {
         for(var key in context) {
           if(context.hasOwnProperty(key)) {
-            if(data) { 
-              data.key = key; 
+            if(data) {
+              data.key = key;
               data.index = i;
               data.first = (i === 0);
             }
@@ -174,7 +174,5 @@ export var logger = {
 export function log(level, obj) { logger.log(level, obj); }
 
 export var createFrame = function(object) {
-  var obj = {};
-  Utils.extend(obj, object);
-  return obj;
+  return Utils.extend({}, object);
 };

--- a/lib/handlebars/compiler/javascript-compiler.js
+++ b/lib/handlebars/compiler/javascript-compiler.js
@@ -21,8 +21,7 @@ JavaScriptCompiler.prototype = {
       ret = parent + "[" + name + "]";
     } else if (JavaScriptCompiler.isValidJavaScriptVariableName(name)) {
       ret = parent + "." + name;
-    }
-    else {
+    } else {
       ret = parent + "['" + name + "']";
     }
 
@@ -168,7 +167,7 @@ JavaScriptCompiler.prototype = {
       this.pushSource("return buffer;");
     }
 
-    var params = this.isChild ? ["depth0", "data"] : ["Handlebars", "depth0", "helpers", "partials", "data"];
+    var params = this.isChild ? ["depth0", "data"] : [this.namespace, "depth0", "helpers", "partials", "data"];
 
     for(var i=0, l=this.environment.depths.list.length; i<l; i++) {
       params.push("depth" + this.environment.depths.list[i]);
@@ -819,6 +818,18 @@ JavaScriptCompiler.prototype = {
       .replace(/\u2029/g, '\\u2029') + '"';
   },
 
+  setupHash: function(obj) {
+    var pairs = [];
+
+    for (var key in obj) {
+      if (obj.hasOwnProperty(key)) {
+        pairs.push(this.quotedString(key) + ':' + obj[key]);
+      }
+    }
+
+    return '{' + pairs.join(',') + '}';
+  },
+
   setupHelper: function(paramSize, name, blockHelper) {
     var params = [],
         paramsInit = this.setupParams(name, paramSize, params, blockHelper);
@@ -833,14 +844,14 @@ JavaScriptCompiler.prototype = {
   },
 
   setupOptions: function(helper, paramSize, params) {
-    var options = [], contexts = [], types = [], param, inverse, program;
+    var options = {}, contexts = [], types = [], param, inverse, program;
 
-    options.push("name:" + this.quotedString(helper));
-    options.push("hash:" + this.popStack());
+    options.name = this.quotedString(helper);
+    options.hash = this.popStack();
 
     if (this.stringParams) {
-      options.push("hashTypes:" + this.popStack());
-      options.push("hashContexts:" + this.popStack());
+      options.hashTypes = this.popStack();
+      options.hashContexts = this.popStack();
     }
 
     inverse = this.popStack();
@@ -859,27 +870,27 @@ JavaScriptCompiler.prototype = {
         inverse = "self.noop";
       }
 
-      options.push("inverse:" + inverse);
-      options.push("fn:" + program);
+      options.fn = program;
+      options.inverse = inverse;
     }
 
-    for(var i=0; i<paramSize; i++) {
+    for (var i = 0; i < paramSize; i++) {
       param = this.popStack();
       params.push(param);
 
-      if(this.stringParams) {
+      if (this.stringParams) {
         types.push(this.popStack());
         contexts.push(this.popStack());
       }
     }
 
     if (this.stringParams) {
-      options.push("contexts:[" + contexts.join(",") + "]");
-      options.push("types:[" + types.join(",") + "]");
+      options.types = "[" + types.join(",") + "]";
+      options.contexts = "[" + contexts.join(",") + "]";
     }
 
-    if(this.options.data) {
-      options.push("data:data");
+    if (this.options.data) {
+      options.data = "data";
     }
 
     return options;
@@ -888,7 +899,7 @@ JavaScriptCompiler.prototype = {
   // the params and contexts arguments are passed in arrays
   // to fill in
   setupParams: function(helperName, paramSize, params, useRegister) {
-    var options = '{' + this.setupOptions(helperName, paramSize, params).join(',') + '}';
+    var options = this.setupHash(this.setupOptions(helperName, paramSize, params));
 
     if (useRegister) {
       this.useRegister('options');

--- a/lib/handlebars/runtime.js
+++ b/lib/handlebars/runtime.js
@@ -67,10 +67,9 @@ export function template(templateSpec, env) {
       var ret = param || common;
 
       if (param && common && (param !== common)) {
-        ret = {};
-        Utils.extend(ret, common);
-        Utils.extend(ret, param);
+        ret = Utils.extend({}, common, param);
       }
+
       return ret;
     },
     programWithDepth: env.VM.programWithDepth,

--- a/lib/handlebars/utils.js
+++ b/lib/handlebars/utils.js
@@ -17,12 +17,16 @@ function escapeChar(chr) {
   return escape[chr] || "&amp;";
 }
 
-export function extend(obj, value) {
-  for(var key in value) {
-    if(Object.prototype.hasOwnProperty.call(value, key)) {
-      obj[key] = value[key];
+export function extend(obj /* , ...source */) {
+  for (var i = 1; i < arguments.length; i++) {
+    for (var key in arguments[i]) {
+      if (Object.prototype.hasOwnProperty.call(arguments[i], key)) {
+        obj[key] = arguments[i][key];
+      }
     }
   }
+
+  return obj;
 }
 
 export var toString = Object.prototype.toString;


### PR DESCRIPTION
- Improves usefulness of `extend` utility
- Properly use the namespace in the JavaScript compiler output
- Update `setupOptions` to return an object, which is much simpler to work with in extended implementations
