### PR TITLE
Access to root context in partials and helpers

### DIFF
--- a/lib/handlebars/compiler/javascript-compiler.js
+++ b/lib/handlebars/compiler/javascript-compiler.js
@@ -121,7 +121,7 @@ JavaScriptCompiler.prototype = {
 
       var copies = "helpers = this.merge(helpers, " + namespace + ".helpers);";
       if (this.environment.usePartial) { copies = copies + " partials = this.merge(partials, " + namespace + ".partials);"; }
-      if (this.options.data) { copies = copies + " data = data || {};"; }
+      if (this.options.data) { copies = copies + " data = this.initData(depth0, data);"; }
       out.push(copies);
     } else {
       out.push('');

--- a/lib/handlebars/runtime.js
+++ b/lib/handlebars/runtime.js
@@ -1,6 +1,6 @@
 module Utils from "./utils";
 import Exception from "./exception";
-import { COMPILER_REVISION, REVISION_CHANGES } from "./base";
+import { COMPILER_REVISION, REVISION_CHANGES, createFrame } from "./base";
 
 export function checkRevision(compilerInfo) {
   var compilerRevision = compilerInfo && compilerInfo[0] || 1,
@@ -55,6 +55,13 @@ export function template(templateSpec, env) {
         programWrapper = this.programs[i] = program(i, fn);
       }
       return programWrapper;
+    },
+    initData: function(context, data) {
+      data = data ? createFrame(data) : {};
+      if (!('root' in data)) {
+        data.root = context;
+      }
+      return data;
     },
     merge: function(param, common) {
       var ret = param || common;

--- a/spec/data.js
+++ b/spec/data.js
@@ -236,4 +236,19 @@ describe('data', function() {
     equals("sad world?", result, "Overriden data output by helper");
   });
 
+  describe('@root', function() {
+    it('the root context can be looked up via @root', function() {
+      var template = CompilerContext.compile('{{@root.foo}}');
+      var result = template({foo: 'hello'}, { data: {} });
+      equals('hello', result);
+
+      result = template({foo: 'hello'}, {});
+      equals('hello', result);
+    });
+    it('passed root values take priority', function() {
+      var template = CompilerContext.compile('{{@root.foo}}');
+      var result = template({}, { data: {root: {foo: 'hello'} } });
+      equals('hello', result);
+    });
+  });
 });

--- a/spec/expected/empty.amd.js
+++ b/spec/expected/empty.amd.js
@@ -2,7 +2,7 @@ define(['handlebars.runtime'], function(Handlebars) {
   Handlebars = Handlebars["default"];  var template = Handlebars.template, templates = Handlebars.templates = Handlebars.templates || {};
 return templates['empty'] = template(function (Handlebars,depth0,helpers,partials,data) {
   this.compilerInfo = [4,'>= 1.0.0'];
-helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
+helpers = this.merge(helpers, Handlebars.helpers); data = this.initData(depth0, data);
   var buffer = "";
 
 


### PR DESCRIPTION
There is already a related bug about getting parent context inside a partial called from within a block helper: issue #182. However, tracking parent context is probably not enough - add in another block helper (e.g. an if inside an each) and things quickly get out of hand. 

The same story with helpers - it's easy enough to get current context via this, it's easy enough to pass in parent context via ".." - but once again, very quickly it becomes "../../../.." There is a hack proposed in issue #245 but I had mixed fortune with it.

The above two problems seriously affect code re-use - one must always keep track of context and nesting. There are pull requests for parentContext by introducing helpers and passing explicit parent context. While I find that useful, I also need the global context - just a couple of sample use cases: localization (must know which language to use), changing some item layout/details based on user status (essentially access check, although some might argue this is "logic" and should thus not be done inside a template).

It would be great to have access to global/root context at all times - inside an {{#each}}, inside an {{#if}}, inside any helper that I create myself and naturally inside any partials that may be nested inside block helpers.
