### PR TITLE
Unable to lookup array values using @index

### DIFF
--- a/lib/handlebars/base.js
+++ b/lib/handlebars/base.js
@@ -193,6 +193,10 @@ function registerDefaultHelpers(instance) {
     var level = options.data && options.data.level != null ? parseInt(options.data.level, 10) : 1;
     instance.log(level, context);
   });
+
+  instance.registerHelper('lookup', function(obj, field, options) {
+    return obj && obj[field];
+  });
 }
 
 export var logger = {

--- a/lib/handlebars/compiler/compiler.js
+++ b/lib/handlebars/compiler/compiler.js
@@ -85,7 +85,8 @@ Compiler.prototype = {
       'if': true,
       'unless': true,
       'with': true,
-      'log': true
+      'log': true,
+      'lookup': true
     };
     if (knownHelpers) {
       for (var name in knownHelpers) {

--- a/spec/builtins.js
+++ b/spec/builtins.js
@@ -203,4 +203,25 @@ describe('builtin helpers', function() {
     equals("whee", logArg, "should call log with 'whee'");
   });
 
+
+  describe('#lookup', function() {
+    it('should lookup arbitrary content', function() {
+      var string = '{{#each goodbyes}}{{lookup ../data .}}{{/each}}',
+          hash   = {goodbyes: [0, 1], data: ['foo', 'bar']};
+
+      var template = CompilerContext.compile(string);
+      var result = template(hash);
+
+      equal(result, 'foobar');
+    });
+    it('should not fail on undefined value', function() {
+      var string = '{{#each goodbyes}}{{lookup ../bar .}}{{/each}}',
+          hash   = {goodbyes: [0, 1], data: ['foo', 'bar']};
+
+      var template = CompilerContext.compile(string);
+      var result = template(hash);
+
+      equal(result, '');
+    });
+  });
 });


### PR DESCRIPTION
When we are working with {{#each}}  helper we are facing following issue.

JSON: {arr1 : ["a","v"],arr2 : ["c","d"]}

Template:
{{#each arr1}}
{{../arr2.[0]}}
{{/each}}

Above code is  working fine. But when we use @index insteated of static index number in the arr2 its not working. we couldn't understand why @index value is not placed. 

For Example (Not working),

Template:1
{{#each arr1}}
{{../arr2.[@index]}}
{{/each}}

Template:2
{{#each arr1}}
{{../arr2.[index]}}
{{/each}}
