### PR TITLE
updated grunt-saucelabs, failing tests revealed

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "grunt-contrib-requirejs": "~0.4.1",
     "grunt-contrib-uglify": "~0.2.2",
     "grunt-contrib-watch": "~0.5.3",
-    "grunt-saucelabs": "~4.1.2",
+    "grunt-saucelabs": "~5.0.1",
     "es6-module-packager": "1.x",
     "jison": "~0.3.0",
     "keen.io": "0.0.3",

--- a/spec/amd.html
+++ b/spec/amd.html
@@ -62,11 +62,41 @@
           window.Handlebars = Handlebars['default'];
 
           require(['tests'], function(Handlebars) {
+            mocha.globals(['mochaResults'])
             // The test harness leaks under FF. We should have decent global leak coverage from other tests
             if (!navigator.userAgent.match(/Firefox\/([\d.]+)/)) {
               mocha.checkLeaks();
             }
-            mocha.run();
+            var runner = mocha.run();
+
+            //Reporting for saucelabs
+            var failedTests = [];
+            runner.on('end', function(){
+              window.mochaResults = runner.stats;
+              window.mochaResults.reports = failedTests;
+            });
+
+            runner.on('fail', logFailure);
+
+            function logFailure(test, err){
+
+              var flattenTitles = function(test){
+                var titles = [];
+                while (test.parent.title){
+                  titles.push(test.parent.title);
+                  test = test.parent;
+                }
+                return titles.reverse();
+              };
+
+              failedTests.push({
+                name: test.title,
+                result: false,
+                message: err.message,
+                stack: err.stack,
+                titles: flattenTitles(test)
+              });
+            };
           });
         });
       };

--- a/spec/index.html
+++ b/spec/index.html
@@ -50,11 +50,41 @@
     <script src="/tmp/tests.js"></script>
     <script>
       onload = function(){
+        mocha.globals(['mochaResults'])
         // The test harness leaks under FF. We should have decent global leak coverage from other tests
         if (!navigator.userAgent.match(/Firefox\/([\d.]+)/)) {
           mocha.checkLeaks();
         }
-        mocha.run();
+        var runner = mocha.run();
+
+        //Reporting for saucelabs
+        var failedTests = [];
+        runner.on('end', function(){
+          window.mochaResults = runner.stats;
+          window.mochaResults.reports = failedTests;
+        });
+
+        runner.on('fail', logFailure);
+
+        function logFailure(test, err){
+
+          var flattenTitles = function(test){
+            var titles = [];
+            while (test.parent.title){
+              titles.push(test.parent.title);
+              test = test.parent;
+            }
+            return titles.reverse();
+          };
+
+          failedTests.push({
+            name: test.title,
+            result: false,
+            message: err.message,
+            stack: err.stack,
+            titles: flattenTitles(test)
+          });
+        };
       };
     </script>
   </head>


### PR DESCRIPTION
grunt-saucelabs has been upgraded to use the Sauce Labs unit test API rather than using wd.js to manually use selenium to look for test results on the page. The new version requires code to report the unit test results on the page, but ends up being way more robust than looking for elements.

For example, turns out that a large number of tests in the handlebars test suite fail! The fault looks like it actually lies in Mocha and not handlebars. Half the tests report `passed: 0 failed: 0 total: 0` because mocha isn't even running correctly.

The tests silently passed before because 0 failing is good, right? Well the new way of doing things causes the js on the page to fail, so Sauce fails the test since results aren't reported.
