### PR TITLE
properly handle multiple subexpressions in the same hash, fixes #748

### DIFF
--- a/lib/handlebars/compiler/compiler.js
+++ b/lib/handlebars/compiler/compiler.js
@@ -188,15 +188,15 @@ Compiler.prototype = {
   },
 
   hash: function(hash) {
-    var pairs = hash.pairs, pair;
+    var pairs = hash.pairs, i, l;
 
     this.opcode('pushHash');
 
-    for(var i=0, l=pairs.length; i<l; i++) {
-      pair = pairs[i];
-
-      this.pushParam(pair[1]);
-      this.opcode('assignToHash', pair[0]);
+    for(i=0, l=pairs.length; i<l; i++) {
+      this.pushParam(pairs[i][1]);
+    }
+    while(i--) {
+      this.opcode('assignToHash', pairs[i][0]);
     }
     this.opcode('popHash');
   },

--- a/lib/handlebars/compiler/javascript-compiler.js
+++ b/lib/handlebars/compiler/javascript-compiler.js
@@ -606,11 +606,10 @@ JavaScriptCompiler.prototype = {
 
   // [assignToHash]
   //
-  // On stack, before: value, hash, ...
-  // On stack, after: hash, ...
+  // On stack, before: value, ..., hash, ...
+  // On stack, after: ..., hash, ...
   //
-  // Pops a value and hash off the stack, assigns `hash[key] = value`
-  // and pushes the hash back onto the stack.
+  // Pops a value off the stack and assigns it to the current hash
   assignToHash: function(key) {
     var value = this.popStack(),
         context,

--- a/spec/subexpressions.js
+++ b/spec/subexpressions.js
@@ -89,6 +89,23 @@ describe('subexpressions', function() {
     shouldCompileTo(string, [{}, helpers], "val is true");
   });
 
+  it("multiple subexpressions in a hash", function() {
+    var string = '{{input aria-label=(t "Name") placeholder=(t "Example User")}}';
+
+    var helpers = {
+      input: function(options) {
+        var hash        = options.hash;
+        var ariaLabel   = Handlebars.Utils.escapeExpression(hash['aria-label']);
+        var placeholder = Handlebars.Utils.escapeExpression(hash.placeholder);
+        return new Handlebars.SafeString('<input aria-label="' + ariaLabel + '" placeholder="' + placeholder + '" />');
+      },
+      t: function(defaultString) {
+        return new Handlebars.SafeString(defaultString);
+      }
+    }
+    shouldCompileTo(string, [{}, helpers], '<input aria-label="Name" placeholder="Example User" />');
+  });
+
   it("in string params mode,", function() {
     var template = CompilerContext.compile('{{snog (blorg foo x=y) yeah a=b}}', {stringParams: true});
 


### PR DESCRIPTION
push all hash params before popping any so as to avoid the last stackN var
stomping previous ones
