### PR TITLE
fix bug in IE<=8 (no Array::map), closes #751

### DIFF
--- a/lib/handlebars/compiler/javascript-compiler.js
+++ b/lib/handlebars/compiler/javascript-compiler.js
@@ -83,12 +83,13 @@ JavaScriptCompiler.prototype = {
 
     this.compileChildren(environment, options);
 
-    var opcodes = environment.opcodes, opcode;
+    var opcodes = environment.opcodes,
+        opcode,
+        i,
+        l;
 
-    this.i = 0;
-
-    for(var l=opcodes.length; this.i<l; this.i++) {
-      opcode = opcodes[this.i];
+    for (i = 0, l = opcodes.length; i < l; i++) {
+      opcode = opcodes[i];
 
       if(opcode.opcode === 'DECLARE') {
         this[opcode.name] = opcode.value;
@@ -115,11 +116,12 @@ JavaScriptCompiler.prototype = {
         compiler: this.compilerInfo(),
         main: fn
       };
-      this.context.programs.map(function(program, index) {
-        if (program) {
-          ret[index] = program;
+      var programs = this.context.programs;
+      for (i = 0, l = programs.length; i < l; i++) {
+        if (programs[i]) {
+          ret[i] = programs[i];
         }
-      });
+      }
 
       if (this.environment.usePartial) {
         ret.usePartial = true;


### PR DESCRIPTION
looks like this broke in 2812fe27

also s/this.i/var i/, since the functions that needed it were removed in
a1edab6ef
