### PR TITLE
Add "browser" field to package.json to better support browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "author": "Yehuda Katz",
   "license": "MIT",
   "readmeFilename": "README.md",
+  "browser": "./lib/handlebars.js",
   "engines": {
     "node": ">=0.4.7"
   },


### PR DESCRIPTION
In a project which uses handlebars and [browserify](http://browserify.org/), module-deps app.js fails with this error:

`
"deps":{"handlebars":"/home/andornaut/workspace/foo/node_modules/handlebars/lib/index.js"}}
stream.js:94
      throw er; // Unhandled stream error in pipe.
            ^
Error: Cannot find module '../dist/cjs/handlebars' from '/home/andornaut/workspace/foo/node_modules/handlebars/lib'
    at /usr/local/lib/node_modules/module-deps/node_modules/resolve/lib/async.js:36:25
    at load (/usr/local/lib/node_modules/module-deps/node_modules/resolve/lib/async.js:54:43)
    at /usr/local/lib/node_modules/module-deps/node_modules/resolve/lib/async.js:60:22
    at /usr/local/lib/node_modules/module-deps/node_modules/resolve/lib/async.js:16:47
    at Object.oncomplete (fs.js:107:15)
`

This can be fixed by adding a [browser](https://gist.github.com/defunctzombie/4339901) field to package.json

I believe that a similar fix was recently applied to [backbone.layoutmanager](https://github.com/tbranyen/backbone.layoutmanager/commit/40bb604810130e5af9aa2044fe59fc9aa59f0426)

n.b. I'm not certain that this is the most ideal method of resolving this issue.
