### PR TITLE
Ensure isHelper is coerced to a boolean

### DIFF
--- a/lib/handlebars/compiler/ast.js
+++ b/lib/handlebars/compiler/ast.js
@@ -86,7 +86,7 @@ var AST = {
     // a mustache is definitely a helper if:
     // * it is an eligible helper, and
     // * it has at least one parameter or hash segment
-    this.isHelper = params.length || hash;
+    this.isHelper = !!(params.length || hash);
 
     // a mustache is an eligible helper if:
     // * its id is simple (a single part, not `this` or `..`)


### PR DESCRIPTION
This change would make isHelper always boolean valued. Nested sexprs always have `isHelper = true` [as seen here](https://github.com/wycats/handlebars.js/blob/085e5e1937b442a4d4add5525db2627e825538aa/src/handlebars.yy#L90) but currently root sexprs are not.
