### PR TITLE
Pass full helper ID to helperMissing when options are provided

### DIFF
--- a/lib/handlebars/compiler/compiler.js
+++ b/lib/handlebars/compiler/compiler.js
@@ -276,7 +276,7 @@ Compiler.prototype = {
       throw new Exception("You specified knownHelpersOnly, but used the unknown helper " + name, sexpr);
     } else {
       this.ID(id);
-      this.opcode('invokeHelper', params.length, name, sexpr.isRoot);
+      this.opcode('invokeHelper', params.length, id.original, sexpr.isRoot);
     }
   },
 

--- a/spec/helpers.js
+++ b/spec/helpers.js
@@ -291,6 +291,7 @@ describe('helpers', function() {
       shouldCompileTo(string, [hash, helpers], "Message: Goodbye cruel world", "block helpers with multiple params");
     });
   });
+
   describe('hash', function() {
     it("helpers can take an optional hash", function() {
       var template = CompilerContext.compile('{{goodbye cruel="CRUEL" world="WORLD" times=12}}');
@@ -473,6 +474,9 @@ describe('helpers', function() {
       blockHelperMissing: function() {
         return 'missing: ' + arguments[arguments.length-1].name;
       },
+      helperMissing: function() {
+        return 'helper missing: ' + arguments[arguments.length-1].name;
+      },
       helper: function() {
         return 'ran: ' + arguments[arguments.length-1].name;
       }
@@ -501,6 +505,10 @@ describe('helpers', function() {
 
     it('should include full id', function() {
       shouldCompileTo('{{#foo.helper}}{{/foo.helper}}', [{foo: {}}, helpers], 'missing: foo.helper');
+    });
+
+    it('should include full id if a hash is passed', function() {
+      shouldCompileTo('{{#foo.helper bar=baz}}{{/foo.helper}}', [{foo: {}}, helpers], 'helper missing: foo.helper');
     });
   });
 


### PR DESCRIPTION
Presently, there is an inconsistency in how helper names are reported to `helperMissing`/`blockHelperMissing`.

For example, take the following block helper:

``` handlebars
{{#nested/foo-bar}}{{/nested/foo-bar}}
```

Because there is ambiguity here (`nested/foo-bar` may either be a helper or a property path available on the context), it must be resolved at runtime, which is done via the `blockValue` opcode. If there is no `nested/foo-bar` property present, the `blockHelperMissing` hook will be invoked, with the name of the helper passed as the full ID: `nested/foo-bar`.

However (I think due to the recent sexp work, but it may have been there before), introducing hash arguments causes two changes:
1. `helperMissing` is invoked instead of `blockHelperMissing`
2. The helper name is reported as `foo-bar` instead of `nested.foo-bar`

In other words, changing `{{#nested/foo-bar}}{{/nested/foo-bar}}` to `{{#nested/foo-bar name="Steve"}}{{/nested/foo-bar}}` changes which "helper missing" hook is invoked, as well as the arguments passed to it.
## helperMissing vs. blockHelperMissing

Simply adding hash arguments disambiguates whether the mustache is a helper or not. In the case where hash args are present, Handlebars takes a shortcut, eliminates the `blockValue` opcode, and skips directly to `invokeHelper`. I would argue that `invokeHelper` should invoke `blockHelperMissing` instead of `helperMissing` when there's a program provided, but there may be something I'm missing here and this PR doesn't change these semantics.
## Full ID vs. truncated ID

This issue is fatal for Ember because we use `helperMissing`/`blockHelperMissing` to look up components, which may be nested. Because of this issue, using the `{{nested/my-component}}` component will work, but `{{nested/my-component name="Steve"}}` will not.

This PR address this issue by passing the original, non-truncated ID to `helperMissing`, matching the semantics of `blockHelperMissing`.
