### PR TITLE
Add spm support

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,5 +57,8 @@
   },
   "scripts": {
     "test": "grunt"
+  },
+  "spm": {
+    "main": "dist/cjs/handlebars.js"
   }
 }


### PR DESCRIPTION
[spm](http://spmjs.io/) is a package manager for browser. We want to add this config to package.json.

This is the document http://spmjs.io/documentation
