### PR TITLE
Publish alpha versions with `prerelease` tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,9 @@
   "bin": {
     "handlebars": "bin/handlebars"
   },
+  "publishConfig": {
+    "tag": "prerelease"
+  },
   "scripts": {
     "test": "grunt"
   }


### PR DESCRIPTION
Currently, alpha versions are published with `latest` tag. This has the
following consequences:
- when installing the package, with `npm install handlebars` users
  will receive alpha version which is most likely not what they want.
- `npm outdated` will report latest stable as outdated, but its not
  really true - there is no new _stable_ version to update to.

`publishConfig` must be removed, when releasing stable `2.0.0`
