### PR TITLE
Implement false for blocks like mustache(.js) and handlebars.java

### DIFF
--- a/lib/handlebars/base.js
+++ b/lib/handlebars/base.js
@@ -73,7 +73,7 @@ function registerDefaultHelpers(instance) {
 
     if(context === true) {
       return fn(this);
-    } else if(context === false || context == null) {
+    } else if(!context) {
       return inverse(this);
     } else if (isArray(context)) {
       if(context.length > 0) {

--- a/spec/blocks.js
+++ b/spec/blocks.js
@@ -67,6 +67,24 @@ describe('blocks', function() {
       shouldCompileTo(string, hash, "Right On!", "Inverted section rendered when value is false.");
     });
 
+    it("inverted section with empty string", function() {
+      var string = "{{#goodbyes}}{{this}}{{/goodbyes}}{{^goodbyes}}Right On!{{/goodbyes}}";
+      var hash = {goodbyes: ""};
+      shouldCompileTo(string, hash, "Right On!", "Inverted section rendered when value is empty string.");
+    });
+
+    it("inverted section with value NaN", function() {
+      var string = "{{#goodbyes}}{{this}}{{/goodbyes}}{{^goodbyes}}Right On!{{/goodbyes}}";
+      var hash = {goodbyes: NaN};
+      shouldCompileTo(string, hash, "Right On!", "Inverted section rendered when value is NaN.");
+    });
+
+    it("inverted section with value 0", function() {
+      var string = "{{#goodbyes}}{{this}}{{/goodbyes}}{{^goodbyes}}Right On!{{/goodbyes}}";
+      var hash = {goodbyes: 0};
+      shouldCompileTo(string, hash, "Right On!", "Inverted section rendered when value is 0.");
+    });
+
     it("inverted section with empty set", function() {
       var string = "{{#goodbyes}}{{this}}{{/goodbyes}}{{^goodbyes}}Right On!{{/goodbyes}}";
       var hash = {goodbyes: []};

--- a/spec/regressions.js
+++ b/spec/regressions.js
@@ -118,10 +118,6 @@ describe('Regressions', function() {
     }, Error, 'You must pass a string or Handlebars AST to Handlebars.precompile. You passed null');
   });
 
-  it('GH-731: zero context rendering', function() {
-    shouldCompileTo('{{#foo}} This is {{bar}} ~ {{/foo}}', {foo: 0, bar: 'OK'}, ' This is  ~ ');
-  });
-
   if (Handlebars.AST) {
     it("can pass through an already-compiled AST via compile/precompile", function() {
       equal(Handlebars.compile(new Handlebars.AST.ProgramNode([ new Handlebars.AST.ContentNode("Hello")]))(), 'Hello');


### PR DESCRIPTION
Essentially I think the following tests should succeed:

```
it("inverted section with empty string", function() {
  var string = "{{#goodbyes}}{{this}}{{/goodbyes}}{{^goodbyes}}Right On!{{/goodbyes}}";
  var hash = {goodbyes: ""};
  shouldCompileTo(string, hash, "Right On!", "Inverted section rendered when value is empty string.");
});

it("inverted section with value NaN", function() {
  var string = "{{#goodbyes}}{{this}}{{/goodbyes}}{{^goodbyes}}Right On!{{/goodbyes}}";
  var hash = {goodbyes: NaN};
  shouldCompileTo(string, hash, "Right On!", "Inverted section rendered when value is NaN.");
});

it("inverted section with value 0", function() {
  var string = "{{#goodbyes}}{{this}}{{/goodbyes}}{{^goodbyes}}Right On!{{/goodbyes}}";
  var hash = {goodbyes: 0};
  shouldCompileTo(string, hash, "Right On!", "Inverted section rendered when value is 0.");
});
```
## Rationale

mustache(5) states

"False Values or Empty Lists

If the person key exists and has a value of false or an empty list, the HTML between the pound and slash will not be displayed."

In javascript 0, NaN and the empty string are false. This is explicitly stated for the Javascript implementation of mustache: https://github.com/janl/mustache.js#false-values-or-empty-lists

(false, undef and empty lists are already interpreted as false in handlebars.js.)

There seem to be a slight disagreement within the moustache community whether the javascript notion of false should be used in all implementation or if you should use the notion for each specific language, but that the implementations in javascript should use the javascript notion of false is clear.
(See discussion in mustache/spec#28 )

It can also be noted that the java implementations of handlebars tries to follow the javascript behavior. The method isEmpty is used to decide if a value is false: https://github.com/jknack/handlebars.java/blob/master/handlebars/src/main/java/com/github/jknack/handlebars/Handlebars.java#L176

So at the moment handlebars.java follows the behaviour of moustache.js but handlebars.js does not. (Something that just bit me...)
