### PR TITLE
Support inverse sections on the with helper

### DIFF
--- a/lib/handlebars/base.js
+++ b/lib/handlebars/base.js
@@ -185,6 +185,8 @@ function registerDefaultHelpers(instance) {
       }
 
       return fn(context, options);
+    } else {
+      return options.inverse(this);
     }
   });
 

--- a/spec/builtins.js
+++ b/spec/builtins.js
@@ -44,6 +44,10 @@ describe('builtin helpers', function() {
       var string = "{{#with person}}{{first}} {{last}}{{/with}}";
       shouldCompileTo(string, {person: function() { return {first: "Alan", last: "Johnson"};}}, "Alan Johnson");
     });
+    it("with with else", function() {
+      var string = "{{#with person}}Person is present{{else}}Person is not present{{/with}}";
+      shouldCompileTo(string, {}, "Person is not present");
+    });
   });
 
   describe('#each', function() {


### PR DESCRIPTION
So that you can write:

```
{{#with something}}
  have something
{{else}}
  don't have it
{{/with}}
```

instead of:

```
{{#with something}}
  have something
{{/with}}
{{#unless something}}
  don't have it
{{/unless}}
```
