### PR TITLE
Lock mocha dependency to ~1.20.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "es6-module-packager": "1.x",
     "jison": "~0.3.0",
     "keen.io": "0.0.3",
-    "mocha": "*",
+    "mocha": "~1.20.0",
     "mustache": "~0.7.2",
     "semver": "~2.1.0",
     "underscore": "~1.5.1"


### PR DESCRIPTION
It seems that the tests are failing in the browser with the latest version of Mocha.
