### PR TITLE
Refactor blocks, programs and inverses

### DIFF
--- a/lib/handlebars/compiler/ast.js
+++ b/lib/handlebars/compiler/ast.js
@@ -1,6 +1,6 @@
 import Exception from "../exception";
 
-function LocationInfo(locInfo){
+function LocationInfo(locInfo) {
   locInfo = locInfo || {};
   this.firstLine   = locInfo.first_line;
   this.firstColumn = locInfo.first_column;
@@ -9,38 +9,11 @@ function LocationInfo(locInfo){
 }
 
 var AST = {
-  ProgramNode: function(statements, inverseStrip, inverse, locInfo) {
-    var inverseLocationInfo, firstInverseNode;
-    if (arguments.length === 3) {
-      locInfo = inverse;
-      inverse = null;
-    } else if (arguments.length === 2) {
-      locInfo = inverseStrip;
-      inverseStrip = null;
-    }
-
+  ProgramNode: function(statements, strip, locInfo) {
     LocationInfo.call(this, locInfo);
     this.type = "program";
     this.statements = statements;
-    this.strip = {};
-
-    if(inverse) {
-      firstInverseNode = inverse[0];
-      if (firstInverseNode) {
-        inverseLocationInfo = {
-          first_line: firstInverseNode.firstLine,
-          last_line: firstInverseNode.lastLine,
-          last_column: firstInverseNode.lastColumn,
-          first_column: firstInverseNode.firstColumn
-        };
-        this.inverse = new AST.ProgramNode(inverse, inverseStrip, inverseLocationInfo);
-      } else {
-        this.inverse = new AST.ProgramNode(inverse, inverseStrip);
-      }
-      this.strip.right = inverseStrip.left;
-    } else if (inverseStrip) {
-      this.strip.left = inverseStrip.right;
-    }
+    this.strip = strip;
   },
 
   MustacheNode: function(rawParams, hash, open, strip, locInfo) {
@@ -106,25 +79,14 @@ var AST = {
     this.strip = strip;
   },
 
-  BlockNode: function(mustache, program, inverse, close, locInfo) {
+  BlockNode: function(mustache, program, inverse, strip, locInfo) {
     LocationInfo.call(this, locInfo);
-
-    if(mustache.sexpr.id.original !== close.path.original) {
-      throw new Exception(mustache.sexpr.id.original + " doesn't match " + close.path.original, this);
-    }
 
     this.type = 'block';
     this.mustache = mustache;
     this.program  = program;
     this.inverse  = inverse;
-
-    this.strip = {
-      left: mustache.strip.left,
-      right: close.strip.right
-    };
-
-    (program || inverse).strip.left = mustache.strip.right;
-    (inverse || program).strip.right = close.strip.left;
+    this.strip = strip;
 
     if (inverse && !program) {
       this.isInverse = true;
@@ -142,7 +104,7 @@ var AST = {
 
     this.type = 'block';
     this.mustache = mustache;
-    this.program = new AST.ProgramNode([content], locInfo);
+    this.program = new AST.ProgramNode([content], {}, locInfo);
   },
 
   ContentNode: function(string, locInfo) {

--- a/lib/handlebars/compiler/base.js
+++ b/lib/handlebars/compiler/base.js
@@ -1,12 +1,19 @@
 import parser from "./parser";
 import AST from "./ast";
+import { stripFlags, prepareBlock } from "./helpers";
 
 export { parser };
 
 export function parse(input) {
   // Just return if an already-compile AST was passed in.
-  if(input.constructor === AST.ProgramNode) { return input; }
+  if (input.constructor === AST.ProgramNode) { return input; }
 
-  parser.yy = AST;
+  for (var key in AST) {
+    parser.yy[key] = AST[key];
+  }
+
+  parser.yy.stripFlags = stripFlags;
+  parser.yy.prepareBlock = prepareBlock;
+
   return parser.parse(input);
 }

--- a/lib/handlebars/compiler/helpers.js
+++ b/lib/handlebars/compiler/helpers.js
@@ -1,0 +1,41 @@
+import Exception from "../exception";
+import AST from "./ast";
+
+export function stripFlags(open, close) {
+  return {
+    left: open.charAt(2) === '~',
+    right: close.charAt(close.length-3) === '~'
+  };
+}
+
+export function prepareBlock(mustache, program, inverseAndProgram, close, inverted, locInfo) {
+  if (mustache.sexpr.id.original !== close.path.original) {
+    throw new Exception(mustache.sexpr.id.original + " doesn't match " + close.path.original, mustache);
+  }
+
+  var inverse, strip;
+
+  strip = {
+    left: mustache.strip.left,
+    right: close.strip.right
+  };
+
+  if (inverseAndProgram) {
+    inverse = inverseAndProgram.program;
+    var inverseStrip = inverseAndProgram.strip;
+
+    program.strip.left = mustache.strip.right;
+    program.strip.right = inverseStrip.left;
+    inverse.strip.left = inverseStrip.right;
+    inverse.strip.right = close.strip.left;
+  } else {
+    program.strip.left = mustache.strip.right;
+    program.strip.right = close.strip.left;
+  }
+
+  if (inverted) {
+    return new AST.BlockNode(mustache, inverse, program, strip, locInfo);
+  } else {
+    return new AST.BlockNode(mustache, program, inverse, strip, locInfo);
+  }
+}

--- a/spec/ast.js
+++ b/spec/ast.js
@@ -68,17 +68,9 @@ describe('ast', function() {
     });
   });
   describe('BlockNode', function() {
-    it('should throw on mustache mismatch (old sexpr-less version)', function() {
-      shouldThrow(function() {
-        var mustacheNode = new handlebarsEnv.AST.MustacheNode([{ original: 'foo'}], null, '{{', {});
-        new handlebarsEnv.AST.BlockNode(mustacheNode, {}, {}, {path: {original: 'bar'}});
-      }, Handlebars.Exception, "foo doesn't match bar");
-    });
     it('should throw on mustache mismatch', function() {
       shouldThrow(function() {
-        var sexprNode = new handlebarsEnv.AST.SexprNode([{ original: 'foo'}], null);
-        var mustacheNode = new handlebarsEnv.AST.MustacheNode(sexprNode, null, '{{', {});
-        new handlebarsEnv.AST.BlockNode(mustacheNode, {}, {}, {path: {original: 'bar'}}, {first_line: 2, first_column: 2});
+        handlebarsEnv.parse("\n  {{#foo}}{{/bar}}")
       }, Handlebars.Exception, "foo doesn't match bar - 2:2");
     });
 
@@ -197,32 +189,12 @@ describe('ast', function() {
       testLocationInfoStorage(pn);
     });
   });
+
   describe("ProgramNode", function(){
 
-    describe("storing location info", function(){
-      it("stores when `inverse` argument isn't passed", function(){
-        var pn = new handlebarsEnv.AST.ProgramNode([], LOCATION_INFO);
-        testLocationInfoStorage(pn);
-      });
-
-      it("stores when `inverse` or `stripInverse` arguments passed", function(){
-        var pn = new handlebarsEnv.AST.ProgramNode([], {strip: {}}, undefined, LOCATION_INFO);
-        testLocationInfoStorage(pn);
-
-        var clone = {
-          strip: {},
-          firstLine: 0,
-          lastLine: 0,
-          firstColumn: 0,
-          lastColumn: 0
-        };
-        pn = new handlebarsEnv.AST.ProgramNode([], {strip: {}}, [ clone ], LOCATION_INFO);
-        testLocationInfoStorage(pn);
-
-        // Assert that the newly created ProgramNode has the same location
-        // information as the inverse
-        testLocationInfoStorage(pn.inverse);
-      });
+    it("storing location info", function(){
+      var pn = new handlebarsEnv.AST.ProgramNode([], {}, LOCATION_INFO);
+      testLocationInfoStorage(pn);
     });
   });
 
@@ -265,11 +237,18 @@ describe('ast', function() {
        testColumns(blockHelperNode, 3, 7, 8, 23);
      });
 
+     it('correctly records the line numbers the program of a block helper', function(){
+       var blockHelperNode = statements[5],
+           program = blockHelperNode.program;
+
+       testColumns(program, 3, 5, 8, 5);
+     });
+
      it('correctly records the line numbers of an inverse of a block helper', function(){
        var blockHelperNode = statements[5],
            inverse = blockHelperNode.inverse;
 
-       testColumns(inverse, 5, 6, 13, 0);
+       testColumns(inverse, 5, 7, 5, 0);
      });
   });
 });

--- a/spec/parser.js
+++ b/spec/parser.js
@@ -121,11 +121,11 @@ describe('parser', function() {
   });
 
   it('parses empty blocks with empty inverse section', function() {
-    equals(ast_for("{{#foo}}{{^}}{{/foo}}"), "BLOCK:\n  {{ ID:foo [] }}\n  PROGRAM:\n");
+    equals(ast_for("{{#foo}}{{^}}{{/foo}}"), "BLOCK:\n  {{ ID:foo [] }}\n  PROGRAM:\n  {{^}}\n");
   });
 
   it('parses empty blocks with empty inverse (else-style) section', function() {
-    equals(ast_for("{{#foo}}{{else}}{{/foo}}"), "BLOCK:\n  {{ ID:foo [] }}\n  PROGRAM:\n");
+    equals(ast_for("{{#foo}}{{else}}{{/foo}}"), "BLOCK:\n  {{ ID:foo [] }}\n  PROGRAM:\n  {{^}}\n");
   });
 
   it('parses non-empty blocks with empty inverse section', function() {

--- a/spec/tokenizer.js
+++ b/spec/tokenizer.js
@@ -237,10 +237,10 @@ describe('Tokenizer', function() {
     shouldMatchTokens(result, ['OPEN_BLOCK', 'ID', 'CLOSE', 'CONTENT', 'OPEN_ENDBLOCK', 'ID', 'CLOSE']);
   });
 
-  it('tokenizes inverse sections as "OPEN_INVERSE CLOSE"', function() {
-    shouldMatchTokens(tokenize("{{^}}"), ['OPEN_INVERSE', 'CLOSE']);
-    shouldMatchTokens(tokenize("{{else}}"), ['OPEN_INVERSE', 'CLOSE']);
-    shouldMatchTokens(tokenize("{{ else }}"), ['OPEN_INVERSE', 'CLOSE']);
+  it('tokenizes inverse sections as "INVERSE"', function() {
+    shouldMatchTokens(tokenize("{{^}}"), ['INVERSE']);
+    shouldMatchTokens(tokenize("{{else}}"), ['INVERSE']);
+    shouldMatchTokens(tokenize("{{ else }}"), ['INVERSE']);
   });
 
   it('tokenizes inverse sections with ID as "OPEN_INVERSE ID CLOSE"', function() {

--- a/src/handlebars.l
+++ b/src/handlebars.l
@@ -75,6 +75,8 @@ ID    [^\s!"#%-,\.\/;->@\[-\^`\{-~]+/{LOOKAHEAD}
 <mu>"{{"{LEFT_STRIP}?">"         return 'OPEN_PARTIAL';
 <mu>"{{"{LEFT_STRIP}?"#"         return 'OPEN_BLOCK';
 <mu>"{{"{LEFT_STRIP}?"/"         return 'OPEN_ENDBLOCK';
+<mu>"{{"{LEFT_STRIP}?"^"\s*{RIGHT_STRIP}?"}}"        this.popState(); return 'INVERSE';
+<mu>"{{"{LEFT_STRIP}?\s*"else"\s*{RIGHT_STRIP}?"}}"  this.popState(); return 'INVERSE';
 <mu>"{{"{LEFT_STRIP}?"^"         return 'OPEN_INVERSE';
 <mu>"{{"{LEFT_STRIP}?\s*"else"   return 'OPEN_INVERSE';
 <mu>"{{"{LEFT_STRIP}?"{"         return 'OPEN_UNESCAPED';


### PR DESCRIPTION
I've untangled the parsing of programs and inverses in blocks. This simplifies the grammar and reduces the amount of parsing logic that has been pushed into the AST Node constructors. Namely, ProgramNode no longer is concerned with inverses and BlockNode no longer requires passing in the closing token.

In order to simplify the grammar further I also added an `INVERSE` token to avoid conflicts with the `openInverse` production. See https://github.com/wycats/handlebars.js/pull/834/files#diff-6.
