### PR TITLE
added getHelper for use in aliasing

### DIFF
--- a/lib/handlebars/base.js
+++ b/lib/handlebars/base.js
@@ -39,6 +39,9 @@ HandlebarsEnvironment.prototype = {
       this.helpers[name] = fn;
     }
   },
+  getHelper: function(name) {
+    return this.helpers[name];
+  },
   unregisterHelper: function(name) {
     delete this.helpers[name];
   },
@@ -49,6 +52,9 @@ HandlebarsEnvironment.prototype = {
     } else {
       this.partials[name] = str;
     }
+  },
+  getPartial: function(name) {
+    return this.partials[name];
   },
   unregisterPartial: function(name) {
     delete this.partials[name];


### PR DESCRIPTION
This would help in aliasing/overriding helpers from external libraries.

```
var old = Handlebars.getHelper('example');
Handlebars.registerHelper("example-old", old);
//...
var newFunc = function(){};
Handlebars.registerHelper("example", newFunc);
```

or

```
var old = Handlebars.getHelper('example');
Handlebars.registerHelper("example", function(value) {
  //do something additional
  return old(value);
});
```
