### PR TITLE
+ jsDelivr CDN info

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -16,6 +16,8 @@ Installing
 ----------
 Installing Handlebars is easy. Simply download the package [from the official site](http://handlebarsjs.com/) or the [bower repository][bower-repo] and add it to your web pages (you should usually use the most recent version).
 
+For web browsers, a free CDN is available at [jsDelivr](http://www.jsdelivr.com/#!handlebarsjs).  Advanced usage, such as [version aliasing & concocting](https://github.com/jsdelivr/jsdelivr#usage), is available. 
+
 Alternatively, if you prefer having the latest version of handlebars from
 the 'master' branch, passing builds of the 'master' branch are automatically
 published to S3. You may download the latest passing master build by grabbing


### PR DESCRIPTION
Thanks to libgrabber, every time a [new release is posted](https://github.com/components/handlebars.js/releases), jsDelivr will find it & automatically upload it.  If you change your file structure, please update the [include section](https://github.com/jsdelivr/jsdelivr/blob/master/files/handlebarsjs/update.json) or ask us to do it.

I was going to link CDNJS also, but they [haven't uploaded to v2.0.0](http://cdnjs.com/libraries/handlebars.js).  Nothing against those cats; we [use their network](http://www.jsdelivr.com/network.php).
