### PR TITLE
Use toHTML vs. instanceof checks for SafeString

### DIFF
--- a/lib/handlebars/safe-string.js
+++ b/lib/handlebars/safe-string.js
@@ -3,7 +3,7 @@ function SafeString(string) {
   this.string = string;
 }
 
-SafeString.prototype.toString = function() {
+SafeString.prototype.toString = SafeString.prototype.toHTML = function() {
   return "" + this.string;
 };
 

--- a/lib/handlebars/utils.js
+++ b/lib/handlebars/utils.js
@@ -53,8 +53,8 @@ export var isArray = Array.isArray || function(value) {
 
 export function escapeExpression(string) {
   // don't escape SafeStrings, since they're already safe
-  if (string instanceof SafeString) {
-    return string.toString();
+  if (string && string.toHTML) {
+    return string.toHTML();
   } else if (string == null) {
     return "";
   } else if (!string) {

--- a/spec/utils.js
+++ b/spec/utils.js
@@ -25,6 +25,12 @@ describe('utils', function() {
       var string = new Handlebars.SafeString('foo<&"\'>');
       equals(Handlebars.Utils.escapeExpression(string), 'foo<&"\'>');
 
+      var obj = {
+        toHTML: function() {
+          return 'foo<&"\'>';
+        }
+      };
+      equals(Handlebars.Utils.escapeExpression(obj), 'foo<&"\'>');
     });
     it('should handle falsy', function() {
       equals(Handlebars.Utils.escapeExpression(''), '');


### PR DESCRIPTION
Allows for us to play nicely in environments such as Node that could have
multiple versions of the library loaded. Also allows for implementors to
provide their own behavior, provided they know what they are doing.

Fixes #886
