### PR TITLE
Exists a bug when use {{log 'Look here!'}}

### DIFF
--- a/lib/handlebars/base.js
+++ b/lib/handlebars/base.js
@@ -211,7 +211,7 @@ export var logger = {
 
   // Can be overridden in the host environment
   log: function(level, message) {
-    if (logger.level <= level) {
+    if (logger.level >= level) {
       var method = logger.methodMap[level];
       if (typeof console !== 'undefined' && console[method]) {
         console[method].call(console, message);


### PR DESCRIPTION
level is an argument, and it should be in (0, 1, 2, 3), logger.level is a constant always queals 3 as your defined! So here should use greater than (>=), or there will never exec this statement!
