### PR TITLE
Add instructions for 'spec/mustache' to CONTRIBUTING.md, fix a few typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,8 @@ To build Handlebars.js you'll need a few things installed.
 * Node.js
 * [Grunt](http://gruntjs.com/getting-started)
 
+Before building, you need to make sure that the Git submodule `spec/mustache` is included (i.e. the directory `spec/mustache` should not be empty). To include it, if using Git version 1.6.5 or newer, use `git clone --recursive` rather than `git clone`. Or, if you already cloned without `--recursive`, use `git submodule update --init`.
+
 Project dependencies may be installed via `npm install`.
 
 To build Handlebars.js from scratch, you'll want to run `grunt`

--- a/lib/handlebars/compiler/ast.js
+++ b/lib/handlebars/compiler/ast.js
@@ -111,5 +111,5 @@ var AST = {
 
 
 // Must be exported as an object rather than the root of the module as the jison lexer
-// most modify the object to operate properly.
+// must modify the object to operate properly.
 export default AST;

--- a/lib/handlebars/compiler/base.js
+++ b/lib/handlebars/compiler/base.js
@@ -10,7 +10,7 @@ var yy = {};
 extend(yy, Helpers, AST);
 
 export function parse(input, options) {
-  // Just return if an already-compile AST was passed in.
+  // Just return if an already-compiled AST was passed in.
   if (input.type === 'Program') { return input; }
 
   parser.yy = yy;

--- a/lib/precompiler.js
+++ b/lib/precompiler.js
@@ -27,7 +27,7 @@ module.exports.cli = function(opts) {
   });
 
   if (opts.simple && opts.min) {
-    throw new Handlebars.Exception('Unable to minimze simple output');
+    throw new Handlebars.Exception('Unable to minimize simple output');
   }
   if (opts.simple && (opts.templates.length !== 1 || fs.statSync(opts.templates[0]).isDirectory())) {
     throw new Handlebars.Exception('Unable to output multiple templates in simple mode');

--- a/spec/precompiler.js
+++ b/spec/precompiler.js
@@ -61,7 +61,7 @@ describe('precompiler', function() {
   it('should throw when combining simple and minimized', function() {
     shouldThrow(function() {
       Precompiler.cli({templates: [__dirname], simple: true, min: true});
-    }, Handlebars.Exception, 'Unable to minimze simple output');
+    }, Handlebars.Exception, 'Unable to minimize simple output');
   });
   it('should throw when combining simple and multiple templates', function() {
     shouldThrow(function() {


### PR DESCRIPTION
I was going to just fix a few typos, but I ran into trouble running `grunt` due to not having anything in `spec/mustache`.  So I also added instructions on that to `CONTRIBUTING.md`.  I figured it's fine to do one PR rather than two since the typo fixes are trivial.
