### PR TITLE
store quote type on the StringLiteral AST instance

### DIFF
--- a/lib/handlebars/compiler/ast.js
+++ b/lib/handlebars/compiler/ast.js
@@ -73,11 +73,14 @@ var AST = {
     this.depth    = depth;
   },
 
-  StringLiteral: function(string, locInfo) {
+  StringLiteral: function(string, locInfo, quoteLiteral) {
     this.loc = locInfo;
     this.type = 'StringLiteral';
     this.original =
       this.value = string;
+    this.isSingleQuoted = quoteLiteral === "'";
+    this.isDoubleQuoted = !this.isSingleQuoted;
+    this.quoteType = this.isSingleQuoted ? 'single' : 'double';
   },
 
   NumberLiteral: function(number, locInfo) {

--- a/spec/ast.js
+++ b/spec/ast.js
@@ -93,6 +93,18 @@ describe('ast', function() {
       var string = new handlebarsEnv.AST.StringLiteral("6", LOCATION_INFO);
       testLocationInfoStorage(string);
     });
+
+    it('stores whether it was a double quoted or single quoted string', function(){
+      var string = new handlebarsEnv.AST.StringLiteral("6", LOCATION_INFO, '"');
+      equals(string.isDoubleQuoted, true);
+      equals(string.isSingleQuoted, false);
+      equals(string.quoteType, 'double');
+
+      string = new handlebarsEnv.AST.StringLiteral("6", LOCATION_INFO, '\'');
+      equals(string.isDoubleQuoted, false);
+      equals(string.isSingleQuoted, true);
+      equals(string.quoteType, 'single');
+    });
   });
 
   describe('BooleanLiteral', function(){

--- a/spec/tokenizer.js
+++ b/spec/tokenizer.js
@@ -264,34 +264,34 @@ describe('Tokenizer', function() {
     shouldBeToken(result[3], "ID", "baz");
   });
 
-  it('tokenizes mustaches with String params as "OPEN ID ID STRING CLOSE"', function() {
+  it('tokenizes mustaches with String params as "OPEN ID ID DOUBLE_QUOTED_STRING CLOSE"', function() {
     var result = tokenize("{{ foo bar \"baz\" }}");
-    shouldMatchTokens(result, ['OPEN', 'ID', 'ID', 'STRING', 'CLOSE']);
-    shouldBeToken(result[3], "STRING", "baz");
+    shouldMatchTokens(result, ['OPEN', 'ID', 'ID', 'DOUBLE_QUOTED_STRING', 'CLOSE']);
+    shouldBeToken(result[3], "DOUBLE_QUOTED_STRING", "baz");
   });
 
-  it('tokenizes mustaches with String params using single quotes as "OPEN ID ID STRING CLOSE"', function() {
+  it('tokenizes mustaches with String params using single quotes as "OPEN ID ID SINGLE_QUOTED_STRING CLOSE"', function() {
     var result = tokenize("{{ foo bar \'baz\' }}");
-    shouldMatchTokens(result, ['OPEN', 'ID', 'ID', 'STRING', 'CLOSE']);
-    shouldBeToken(result[3], "STRING", "baz");
+    shouldMatchTokens(result, ['OPEN', 'ID', 'ID', 'SINGLE_QUOTED_STRING', 'CLOSE']);
+    shouldBeToken(result[3], "SINGLE_QUOTED_STRING", "baz");
   });
 
-  it('tokenizes String params with spaces inside as "STRING"', function() {
+  it('tokenizes String params with spaces inside as "DOUBLE_QUOTED_STRING"', function() {
     var result = tokenize("{{ foo bar \"baz bat\" }}");
-    shouldMatchTokens(result, ['OPEN', 'ID', 'ID', 'STRING', 'CLOSE']);
-    shouldBeToken(result[3], "STRING", "baz bat");
+    shouldMatchTokens(result, ['OPEN', 'ID', 'ID', 'DOUBLE_QUOTED_STRING', 'CLOSE']);
+    shouldBeToken(result[3], "DOUBLE_QUOTED_STRING", "baz bat");
   });
 
-  it('tokenizes String params with escapes quotes as STRING', function() {
+  it('tokenizes String params with escapes quotes as DOUBLE_QUOTED_STRING', function() {
     var result = tokenize('{{ foo "bar\\"baz" }}');
-    shouldMatchTokens(result, ['OPEN', 'ID', 'STRING', 'CLOSE']);
-    shouldBeToken(result[2], "STRING", 'bar"baz');
+    shouldMatchTokens(result, ['OPEN', 'ID', 'DOUBLE_QUOTED_STRING', 'CLOSE']);
+    shouldBeToken(result[2], "DOUBLE_QUOTED_STRING", 'bar"baz');
   });
 
-  it('tokenizes String params using single quotes with escapes quotes as STRING', function() {
+  it('tokenizes String params using single quotes with escapes quotes as SINGLE_QUOTED_STRING', function() {
     var result = tokenize("{{ foo 'bar\\'baz' }}");
-    shouldMatchTokens(result, ['OPEN', 'ID', 'STRING', 'CLOSE']);
-    shouldBeToken(result[2], "STRING", "bar'baz");
+    shouldMatchTokens(result, ['OPEN', 'ID', 'SINGLE_QUOTED_STRING', 'CLOSE']);
+    shouldBeToken(result[2], "SINGLE_QUOTED_STRING", "bar'baz");
   });
 
   it('tokenizes numbers', function() {
@@ -342,13 +342,13 @@ describe('Tokenizer', function() {
     shouldMatchTokens(result, ['OPEN', 'ID', 'ID', 'ID', 'EQUALS', 'ID', 'CLOSE']);
 
     result = tokenize("{{ foo bar baz=\"bat\" }}");
-    shouldMatchTokens(result, ['OPEN', 'ID', 'ID', 'ID', 'EQUALS', 'STRING', 'CLOSE']);
+    shouldMatchTokens(result, ['OPEN', 'ID', 'ID', 'ID', 'EQUALS', 'DOUBLE_QUOTED_STRING', 'CLOSE']);
 
     result = tokenize("{{ foo bar baz=\"bat\" bam=wot }}");
-    shouldMatchTokens(result, ['OPEN', 'ID', 'ID', 'ID', 'EQUALS', 'STRING', 'ID', 'EQUALS', 'ID', 'CLOSE']);
+    shouldMatchTokens(result, ['OPEN', 'ID', 'ID', 'ID', 'EQUALS', 'DOUBLE_QUOTED_STRING', 'ID', 'EQUALS', 'ID', 'CLOSE']);
 
     result = tokenize("{{foo omg bar=baz bat=\"bam\"}}");
-    shouldMatchTokens(result, ['OPEN', 'ID', 'ID', 'ID', 'EQUALS', 'ID', 'ID', 'EQUALS', 'STRING', 'CLOSE']);
+    shouldMatchTokens(result, ['OPEN', 'ID', 'ID', 'ID', 'EQUALS', 'ID', 'ID', 'EQUALS', 'DOUBLE_QUOTED_STRING', 'CLOSE']);
     shouldBeToken(result[2], "ID", "omg");
   });
 
@@ -398,7 +398,7 @@ describe('Tokenizer', function() {
 
   it('tokenizes nested subexpressions: literals', function() {
     var result = tokenize("{{foo (bar (lol true) false) (baz 1) (blah 'b') (blorg \"c\")}}");
-    shouldMatchTokens(result, ['OPEN', 'ID', 'OPEN_SEXPR', 'ID', 'OPEN_SEXPR', 'ID', 'BOOLEAN', 'CLOSE_SEXPR', 'BOOLEAN', 'CLOSE_SEXPR', 'OPEN_SEXPR', 'ID', 'NUMBER', 'CLOSE_SEXPR', 'OPEN_SEXPR', 'ID', 'STRING', 'CLOSE_SEXPR', 'OPEN_SEXPR', 'ID', 'STRING', 'CLOSE_SEXPR', 'CLOSE']);
+    shouldMatchTokens(result, ['OPEN', 'ID', 'OPEN_SEXPR', 'ID', 'OPEN_SEXPR', 'ID', 'BOOLEAN', 'CLOSE_SEXPR', 'BOOLEAN', 'CLOSE_SEXPR', 'OPEN_SEXPR', 'ID', 'NUMBER', 'CLOSE_SEXPR', 'OPEN_SEXPR', 'ID', 'SINGLE_QUOTED_STRING', 'CLOSE_SEXPR', 'OPEN_SEXPR', 'ID', 'DOUBLE_QUOTED_STRING', 'CLOSE_SEXPR', 'CLOSE']);
   });
 
   it('tokenizes block params', function() {

--- a/src/handlebars.l
+++ b/src/handlebars.l
@@ -97,8 +97,8 @@ ID    [^\s!"#%-,\.\/;->@\[-\^`\{-~]+/{LOOKAHEAD}
 <mu>\s+                          // ignore whitespace
 <mu>"}"{RIGHT_STRIP}?"}}"        this.popState(); return 'CLOSE_UNESCAPED';
 <mu>{RIGHT_STRIP}?"}}"           this.popState(); return 'CLOSE';
-<mu>'"'("\\"["]|[^"])*'"'        yytext = strip(1,2).replace(/\\"/g,'"'); return 'STRING';
-<mu>"'"("\\"[']|[^'])*"'"        yytext = strip(1,2).replace(/\\'/g,"'"); return 'STRING';
+<mu>'"'("\\"["]|[^"])*'"'        yytext = strip(1,2).replace(/\\"/g,'"'); return 'DOUBLE_QUOTED_STRING';
+<mu>"'"("\\"[']|[^'])*"'"        yytext = strip(1,2).replace(/\\'/g,"'"); return 'SINGLE_QUOTED_STRING';
 <mu>"@"                          return 'DATA';
 <mu>"true"/{LITERAL_LOOKAHEAD}   return 'BOOLEAN';
 <mu>"false"/{LITERAL_LOOKAHEAD}  return 'BOOLEAN';

--- a/src/handlebars.yy
+++ b/src/handlebars.yy
@@ -87,7 +87,8 @@ sexpr
 
 param
   : path -> $1
-  | STRING -> new yy.StringLiteral($1, yy.locInfo(@$))
+  | DOUBLE_QUOTED_STRING -> new yy.StringLiteral($1, yy.locInfo(@$), "'")
+  | SINGLE_QUOTED_STRING -> new yy.StringLiteral($1, yy.locInfo(@$), "\"")
   | NUMBER -> new yy.NumberLiteral($1, yy.locInfo(@$))
   | BOOLEAN -> new yy.BooleanLiteral($1, yy.locInfo(@$))
   | dataName -> $1
@@ -108,7 +109,8 @@ blockParams
 
 helperName
   : path -> $1
-  | STRING -> new yy.StringLiteral($1, yy.locInfo(@$)), yy.locInfo(@$)
+  | DOUBLE_QUOTED_STRING -> new yy.StringLiteral($1, yy.locInfo(@$), "'")
+  | SINGLE_QUOTED_STRING -> new yy.StringLiteral($1, yy.locInfo(@$), "\"")
   | NUMBER -> new yy.NumberLiteral($1, yy.locInfo(@$))
   ;
 


### PR DESCRIPTION
Changes the Grammer to pass DOUBLE_QUOTED_STRING or
SINGLE_QUOTED_STRING instead of STRING, so that information
about the quote type can be passed to the AST nodes.

This can be useful in reprinting an AST without changing
the style of the original template author.

This is part of https://github.com/wycats/handlebars.js/issues/935