### PR TITLE
Add missing reserved words so compiler knows to use array syntax:

### DIFF
--- a/lib/handlebars/compiler/javascript-compiler.js
+++ b/lib/handlebars/compiler/javascript-compiler.js
@@ -1025,7 +1025,8 @@ var reservedWords = (
   " class float package throws" +
   " const goto private transient" +
   " debugger implements protected volatile" +
-  " double import public let yield"
+  " double import public let yield await" +
+  " null true false"
 ).split(" ");
 
 var compilerWords = JavaScriptCompiler.RESERVED_WORDS = {};

--- a/spec/javascript-compiler.js
+++ b/spec/javascript-compiler.js
@@ -19,6 +19,12 @@ describe('javascript-compiler api', function() {
       };
       shouldCompileTo("{{foo}}", { bar_foo: "food" }, "food");
     });
+
+    // Tests nameLookup dot vs. bracket behavior.  Bracket is required in certain cases
+    // to avoid errors in older browsers.
+    it('should handle reserved words', function() {
+      shouldCompileTo("{{foo}} {{~null~}}", { foo: "food" }, "food");
+    });
   });
   describe('#compilerInfo', function() {
     var $superCheck, $superInfo;


### PR DESCRIPTION
The added reserved words are:

* await
* null
* true
* false

IE 8 was failing to compile Handlebars-generated source code
because it had helpers.null.

I came up with this list by diffing
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#Keywords
against the ones Handlebars already had.