### PR TITLE
Boolean literals can be passed to mustaches

### DIFF
--- a/lib/handlebars/compiler/compiler.js
+++ b/lib/handlebars/compiler/compiler.js
@@ -172,11 +172,8 @@ Compiler.prototype = {
   },
 
   MustacheStatement: function(mustache) {
-    if (!mustache.path.type.match(/Literal$/)) {
-      this.SubExpression(mustache);
-    } else {
-      this.accept(mustache.path);
-    }
+    transformLiteralToPath(mustache);
+    this.SubExpression(mustache);
 
     if(mustache.escaped && !this.options.noEscape) {
       this.opcode('appendEscaped');
@@ -487,5 +484,12 @@ function argEquals(a, b) {
       }
     }
     return true;
+  }
+}
+
+function transformLiteralToPath(mustache) {
+  if (mustache.path.type.match(/Literal$/)) {
+    var literal = mustache.path;
+    mustache.path = { type: 'PathExpression', original: String(literal.original), parts: [String(literal.original)], depth: 0, data: false };
   }
 }

--- a/lib/handlebars/compiler/compiler.js
+++ b/lib/handlebars/compiler/compiler.js
@@ -172,7 +172,11 @@ Compiler.prototype = {
   },
 
   MustacheStatement: function(mustache) {
-    this.SubExpression(mustache);
+    if (!mustache.path.type.match(/Literal$/)) {
+      this.SubExpression(mustache);
+    } else {
+      this.accept(mustache.path);
+    }
 
     if(mustache.escaped && !this.options.noEscape) {
       this.opcode('appendEscaped');

--- a/spec/basic.js
+++ b/spec/basic.js
@@ -231,18 +231,20 @@ describe("basic context", function() {
   });
 
   it("pass string literals", function() {
-    shouldCompileTo('{{"foo"}}', {}, "foo", "works with strings");
-    shouldCompileTo('{{"foo"}}', { foo: "bar" }, "foo", "uses the provided string instead of lookup in the context object");
+    shouldCompileTo('{{"foo"}}', {}, "");
+    shouldCompileTo('{{"foo"}}', { foo: "bar" }, "bar");
   });
 
   it("pass number literals", function() {
-    shouldCompileTo("{{12}}", {}, "12", "works with numbers");
-    shouldCompileTo("{{12}}", { "12": "bar" }, "12", "uses the provided number instead of lookup in the context object");
+    shouldCompileTo("{{12}}", {}, "");
+    shouldCompileTo("{{12}}", { "12": "bar" }, "bar");
+    shouldCompileTo("{{12.34}}", {}, "");
+    shouldCompileTo("{{12.34}}", { "12.34": "bar" }, "bar");
   });
 
   it("pass boolean literals", function() {
-    shouldCompileTo("{{true}}", {}, "true", "works with true");
-    shouldCompileTo("{{true}}", { "true": "foo" }, "true", "uses the primitive true instead of lookup in the context object");
-    shouldCompileTo("{{false}}", { "false": "foo" }, "false", "uses the primitive false instead of lookup in the context object");
+    shouldCompileTo("{{true}}", {}, "");
+    shouldCompileTo("{{true}}", { "": "foo" }, "");
+    shouldCompileTo("{{false}}", { "false": "foo" }, "foo");
   });
 });

--- a/spec/basic.js
+++ b/spec/basic.js
@@ -229,4 +229,20 @@ describe("basic context", function() {
       CompilerContext.compile(string);
     }, Error);
   });
+
+  it("pass string literals", function() {
+    shouldCompileTo('{{"foo"}}', {}, "foo", "works with strings");
+    shouldCompileTo('{{"foo"}}', { foo: "bar" }, "foo", "uses the provided string instead of lookup in the context object");
+  });
+
+  it("pass number literals", function() {
+    shouldCompileTo("{{12}}", {}, "12", "works with numbers");
+    shouldCompileTo("{{12}}", { "12": "bar" }, "12", "uses the provided number instead of lookup in the context object");
+  });
+
+  it("pass boolean literals", function() {
+    shouldCompileTo("{{true}}", {}, "true", "works with true");
+    shouldCompileTo("{{true}}", { "true": "foo" }, "true", "uses the primitive true instead of lookup in the context object");
+    shouldCompileTo("{{false}}", { "false": "foo" }, "false", "uses the primitive false instead of lookup in the context object");
+  });
 });

--- a/spec/parser.js
+++ b/spec/parser.js
@@ -10,6 +10,10 @@ describe('parser', function() {
   }
 
   it('parses simple mustaches', function() {
+    equals(ast_for('{{123}}'), "{{ NUMBER{123} [] }}\n");
+    equals(ast_for('{{"foo"}}'), '{{ "foo" [] }}\n');
+    equals(ast_for('{{false}}'), '{{ BOOLEAN{false} [] }}\n');
+    equals(ast_for('{{true}}'), '{{ BOOLEAN{true} [] }}\n');
     equals(ast_for('{{foo}}'), "{{ PATH:foo [] }}\n");
     equals(ast_for('{{foo?}}'), "{{ PATH:foo? [] }}\n");
     equals(ast_for('{{foo_}}'), "{{ PATH:foo_ [] }}\n");

--- a/src/handlebars.yy
+++ b/src/handlebars.yy
@@ -110,6 +110,7 @@ helperName
   | dataName -> $1
   | STRING -> new yy.StringLiteral($1, yy.locInfo(@$)), yy.locInfo(@$)
   | NUMBER -> new yy.NumberLiteral($1, yy.locInfo(@$))
+  | BOOLEAN -> new yy.BooleanLiteral($1, yy.locInfo(@$))
   ;
 
 partialName


### PR DESCRIPTION
In [htmlbars](https://github.com/tildeio/htmlbars), I believe the following component `<x-foo bool=true ></ x-foo>` is transformed to `<x-foo bool={{true}} ></ x-foo>`. But mustaches with boolean literals don't work in handlebars, just numbers. This PR fixes this.

//cc @mmun 