### PR TITLE
default is a reserved word

### DIFF
--- a/runtime.js
+++ b/runtime.js
@@ -1,3 +1,3 @@
 // Create a simple path alias to allow browserify to resolve
 // the runtime on a supported path.
-module.exports = require('./dist/cjs/handlebars.runtime').default;
+module.exports = require('./dist/cjs/handlebars.runtime')['default'];


### PR DESCRIPTION
`default` is a reserved word. Quoting it to fix in older browsers, especially Android 2.3.x. Otherwise, it throws exception on Android 2.3.6 at least.