### PR TITLE
Use `import` instead of `module`

### DIFF
--- a/lib/handlebars/compiler/base.js
+++ b/lib/handlebars/compiler/base.js
@@ -1,12 +1,29 @@
 import parser from "./parser";
 import AST from "./ast";
 import WhitespaceControl from "./whitespace-control";
-module Helpers from "./helpers";
+import {
+  SourceLocation,
+  stripFlags,
+  stripComment,
+  preparePath,
+  prepareMustache,
+  prepareRawBlock,
+  prepareBlock
+} from "./helpers";
 import { extend } from "../utils";
 
 export { parser };
 
 var yy = {};
+var Helpers = {
+  SourceLocation: SourceLocation,
+  stripFlags: stripFlags,
+  stripComment: stripComment,
+  preparePath: preparePath,
+  prepareMustache: prepareMustache,
+  prepareRawBlock: prepareRawBlock,
+  prepareBlock: prepareBlock
+};
 extend(yy, Helpers, AST);
 
 export function parse(input, options) {


### PR DESCRIPTION
* export Helpers as default export in `handlebars/compiler/base`