### PR TITLE
Added handlebars-layouts to the in-the-wild list

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -403,6 +403,7 @@ Handlebars in the Wild
   from Les Hill (@leshill).
 * [handlebars-helpers](https://github.com/assemble/handlebars-helpers) is an extensive library
   with 100+ handlebars helpers.
+* [handlebars-layouts](https://github.com/shannonmoeller/handlebars-layouts) is a set of helpers which implement extendible and embeddable layout blocks as seen in other popular templating languages.
 * [hbs](http://github.com/donpark/hbs): An Express.js view engine adapter for Handlebars.js,
   from Don Park.
 * [koa-hbs](https://github.com/jwilm/koa-hbs): [koa](https://github.com/koajs/koa) generator based


### PR DESCRIPTION
I've written a set of helpers which implement layout blocks similar to Jade, Jinja, Swig, Twig, and others. It seems to be gaining some popularity (around 10k npm downloads per month at present) and I would be honored to have it included in the in-the-wild list in case it may prove useful to others.