### PR TITLE
Fix tokenizer test for double quoted strings

### DIFF
--- a/spec/tokenizer.js
+++ b/spec/tokenizer.js
@@ -264,7 +264,7 @@ describe('Tokenizer', function() {
   });
 
   it('tokenizes mustaches with String params as "OPEN ID ID STRING CLOSE"', function() {
-    var result = tokenize('{{ foo bar \'baz\' }}');
+    var result = tokenize('{{ foo bar \"baz\" }}');
     shouldMatchTokens(result, ['OPEN', 'ID', 'ID', 'STRING', 'CLOSE']);
     shouldBeToken(result[3], 'STRING', 'baz');
   });


### PR DESCRIPTION
There are two consecutive tests with the same input data:

    {{ foo bar \'baz\' }}

I suppose the first test should be about testing double quoted string so I changed its input data to:

    {{ foo bar \"baz\" }}