### PR TITLE
Fix minor typos in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -287,8 +287,8 @@ You can also use real html comments if you want them to end up in the output.
 
 There are a few Mustache behaviors that Handlebars does not implement.
 - Handlebars deviates from Mustache slightly in that it does not perform recursive lookup by default. The compile time `compat` flag must be set to enable this functionality. Users should note that there is a performance cost for enabling this flag. The exact cost varies by template, but it's recommended that performance sensitive operations should avoid this mode and instead opt for explicit path references.
-- The optional Mustache-style lambdas are not supported. Instead Handlebars provides it's own lambda resolution that follows the behaviors of helpers.
-- Alternative delimeters are not supported.
+- The optional Mustache-style lambdas are not supported. Instead Handlebars provides its own lambda resolution that follows the behaviors of helpers.
+- Alternative delimiters are not supported.
 
 
 Precompiling Templates


### PR DESCRIPTION
This fixes two minor typos in the README:

- `it's` vs. `its`
- spelling of `delimiter`
