### PR TITLE
Compile failing when partial is an instance of Handlebars.SafeString

### DIFF
--- a/lib/handlebars/runtime.js
+++ b/lib/handlebars/runtime.js
@@ -49,7 +49,7 @@ export function template(templateSpec, env) {
     }
     if (result != null) {
       if (options.indent) {
-        let lines = result.split('\n');
+        let lines = result.toString().split('\n');
         for (let i = 0, l = lines.length; i < l; i++) {
           if (!lines[i] && i + 1 === l) {
             break;


### PR DESCRIPTION
When partial's `indent` option is used, runtime compilation of string partial is failing for partials produced by `Handlebars.SafeString` because of `split` method call.

```js
let lines = result.split('\n');
```
https://github.com/wycats/handlebars.js/blob/master/lib/handlebars/runtime.js#L52

See [jsfiddle demo](http://jsfiddle.net/j1j60b0u/) for details.

I have fixed it in a straight way by explicitly calling `result.toString()`.