### PR TITLE
Update HelperExpression to be able to evaluate nodes without params a…

### DIFF
--- a/lib/handlebars/compiler/ast.js
+++ b/lib/handlebars/compiler/ast.js
@@ -131,7 +131,7 @@ let AST = {
     // * it is an eligible helper, and
     // * it has at least one parameter or hash segment
     helperExpression: function(node) {
-      return !!(node.type === 'SubExpression' || node.params.length || node.hash);
+      return !!(node.type === 'SubExpression' || (node.params && node.params.length) || node.hash);
     },
 
     scopedId: function(path) {


### PR DESCRIPTION
Update HelperExpression to be able to evaluate nodes without params attribute. 

I want to be able to traverse the entire AST and check if each node/param/hash is a helper or not. This currently blows up on literals that don't have params.