### PR TITLE
Implemented block params support for `each` and `with`

### DIFF
--- a/lib/handlebars/base.js
+++ b/lib/handlebars/base.js
@@ -194,9 +194,20 @@ function registerDefaultHelpers(instance) {
     let fn = options.fn;
 
     if (!Utils.isEmpty(context)) {
+      let contextPath;
       if (options.data && options.ids) {
+        contextPath = Utils.appendContextPath(options.data.contextPath, options.ids[0]);
+      }
+      if (fn.blockParams) {
+        // block param does not change the context
+        return fn(this, {
+          data: options.data,
+          blockParams: Utils.blockParams([context], [contextPath])
+        });
+      }
+      if (contextPath) {
         let data = createFrame(options.data);
-        data.contextPath = Utils.appendContextPath(options.data.contextPath, options.ids[0]);
+        data.contextPath = contextPath;
         options = {data: data};
       }
 

--- a/lib/handlebars/base.js
+++ b/lib/handlebars/base.js
@@ -156,13 +156,13 @@ function registerDefaultHelpers(instance) {
             // We're running the iterations one step out of sync so we can detect
             // the last iteration without have to scan the object twice and create
             // an itermediate keys array.
-            if (priorKey) {
+            if (priorKey !== undefined) {
               execIteration.call(this, priorKey, i++, false);
             }
             priorKey = key;
           }
         }
-        if (priorKey) {
+        if (priorKey !== undefined) {
           execIteration.call(this, priorKey, i++, true);
         }
       }

--- a/lib/handlebars/base.js
+++ b/lib/handlebars/base.js
@@ -103,45 +103,50 @@ function registerDefaultHelpers(instance) {
       throw new Exception('Must pass iterator to #each');
     }
 
-    let fn = options.fn,
-        inverse = options.inverse,
-        i = 0,
-        ret = '',
-        data,
-        contextPath;
-
-    if (options.data && options.ids) {
-      contextPath = Utils.appendContextPath(options.data.contextPath, options.ids[0]) + '.';
-    }
+    let i = 0,
+        ret = '';
 
     if (isFunction(context)) { context = context.call(this); }
 
-    if (options.data) {
-      data = createFrame(options.data);
-    }
+    if (context && typeof context === 'object') {
+      let fn = options.fn,
+          data,
+          contextPath;
 
-    function execIteration(field, index, last) {
-      if (data) {
-        data.key = field;
-        data.index = index;
-        data.first = index === 0;
-        data.last = !!last;
-
-        if (contextPath) {
-          data.contextPath = contextPath + field;
+      if (options.data) {
+        data = fn.blockParams ? options.data : createFrame(options.data);
+        if (options.ids) {
+          contextPath = Utils.appendContextPath(options.data.contextPath, options.ids[0]) + '.';
         }
       }
 
-      ret = ret + fn(context[field], {
-        data: data,
-        blockParams: Utils.blockParams([context[field], field], [contextPath + field, null])
-      });
-    }
+      function execIteration(field, index, last) {
+        if (fn.blockParams) {
+          // block param does not change the context
+          ret += fn(this, {
+            data: data,
+            blockParams: Utils.blockParams(
+              [context[field], field, index, index === 0, !!last],
+              [(contextPath ? contextPath + field : undefined), null, null, null, null]
+            )
+          });
+        } else {
+          if (data) {
+            data.key = field;
+            data.index = index;
+            data.first = index === 0;
+            data.last = last;
+            if (contextPath) {
+              data.contextPath = contextPath + field;
+            }
+          }
+          ret += fn(context[field], {data: data});
+        }
+      }
 
-    if (context && typeof context === 'object') {
       if (isArray(context)) {
-        for (let j = context.length; i < j; i++) {
-          execIteration(i, i, i === context.length - 1);
+        for (let len = context.length; i < len; /* incremented below */) {
+          execIteration.call(this, i, i, ++i === len);
         }
       } else {
         let priorKey;
@@ -152,20 +157,19 @@ function registerDefaultHelpers(instance) {
             // the last iteration without have to scan the object twice and create
             // an itermediate keys array.
             if (priorKey) {
-              execIteration(priorKey, i - 1);
+              execIteration.call(this, priorKey, i++, false);
             }
             priorKey = key;
-            i++;
           }
         }
         if (priorKey) {
-          execIteration(priorKey, i - 1, true);
+          execIteration.call(this, priorKey, i++, true);
         }
       }
     }
 
     if (i === 0) {
-      ret = inverse(this);
+      ret = options.inverse(this);
     }
 
     return ret;

--- a/spec/builtins.js
+++ b/spec/builtins.js
@@ -136,14 +136,28 @@ describe('builtin helpers', function() {
       equal(result, '0. goodbye! 0 1 2 After 0 1. Goodbye! 0 1 2 After 1 2. GOODBYE! 0 1 2 After 2 cruel world!', 'The @index variable is used');
     });
 
+    it('each should change context', function() {
+      var string = '{{#each foo}}{{.}}{{bar}}{{@key}} {{@index}} {{@first}} {{@last}} {{baz}}{{/each}}';
+      var hash = {foo: ['a', 'b', 'c'], bar: 'd', baz: 'e'};
+      shouldCompileTo(string, hash, 'a0 0 true false b1 1 false false c2 2 false true ');
+    });
+
     it('each with block params', function() {
-      var string = '{{#each goodbyes as |value index|}}{{index}}. {{value.text}}! {{#each ../goodbyes as |childValue childIndex|}} {{index}} {{childIndex}}{{/each}} After {{index}} {{/each}}{{index}}cruel {{world}}!';
+      var string = '{{#each goodbyes as |value index|}}{{index}}. {{value.text}}! {{#each goodbyes as |childValue childIndex|}} {{index}} {{childIndex}}{{/each}} After {{index}} {{/each}}{{index}}cruel {{world}}!';
       var hash = {goodbyes: [{text: 'goodbye'}, {text: 'Goodbye'}], world: 'world'};
+      shouldCompileTo(string, hash, '0. goodbye!  0 0 0 1 After 0 1. Goodbye!  1 0 1 1 After 1 cruel world!');
+    });
 
-      var template = CompilerContext.compile(string);
-      var result = template(hash);
+    it('each with block params should not change context', function() {
+      var string = '{{#each foo as |bar barKey barIndex barFirst barLast|}}{{.}}{{bar}}{{barKey}} {{barIndex}} {{barFirst}} {{barLast}} {{baz}}{{/each}}';
+      var hash = {foo: ['a', 'b', 'c'], bar: 'd', baz: 'e', toString: function() { return 'f'; } };
+      shouldCompileTo(string, hash, 'fa0 0 true false efb1 1 false false efc2 2 false true e');
+    });
 
-      equal(result, '0. goodbye!  0 0 0 1 After 0 1. Goodbye!  1 0 1 1 After 1 cruel world!');
+    it('each with block params should nest', function() {
+      var string = '{{#each foo as |bar|}}{{#each bar as |baz|}}{{baz}}{{/each}}/{{/each}}';
+      var hash = {foo: [ ['a', 'b', 'c'], ['d', 'e', 'f'] ] };
+      shouldCompileTo(string, hash, 'abc/def/');
     });
 
     it('each object with @index', function() {

--- a/spec/builtins.js
+++ b/spec/builtins.js
@@ -49,7 +49,7 @@ describe('builtin helpers', function() {
     });
     it('with should change context', function() {
       var string = '{{#with foo}}{{.}}/{{foo}}{{bar}}{{baz}}{{/with}}';
-      shouldCompileTo(string, {foo: 1, bar: 2, baz: 3}, '1/');
+      shouldCompileTo(string, {foo: 'a', bar: 'b', baz: 'c'}, 'a/');
     });
     it('with with block params', function() {
       var string = '{{#with person as |p|}}{{p.first}} {{p.last}}{{/with}}';
@@ -57,7 +57,7 @@ describe('builtin helpers', function() {
     });
     it('with with block params should not change context', function() {
       var string = '{{#with foo as |bar|}}{{.}}/{{foo}}{{bar}}{{baz}}{{/with}}';
-      shouldCompileTo(string, {foo: 1, bar: 2, baz: 3, toString: function() { return '!'; }}, '!/113');
+      shouldCompileTo(string, {foo: 'a', bar: 'b', baz: 'c', toString: function() { return 'd'; }}, 'd/aac');
     });
   });
 

--- a/spec/builtins.js
+++ b/spec/builtins.js
@@ -49,19 +49,19 @@ describe('builtin helpers', function() {
     });
     it('with should change context', function() {
       var string = '{{#with foo}}{{foo}}{{bar}}{{baz}}/{{.}}{{/with}}/{{foo}}{{bar}}{{baz}}';
-      shouldCompileTo(string, {foo: 'a', bar: 'b', baz: 'c'}, '/a/abc');
+      shouldCompileTo(string, {foo: 'a', bar: 'b', baz: 'c'}, '/a/abc', 'should change context');
     });
     it('with with block params', function() {
       var string = '{{#with person as |p|}}{{p.first}} {{p.last}}{{/with}}';
-      shouldCompileTo(string, {person: {first: 'Alan', last: 'Johnson'}}, 'Alan Johnson');
+      shouldCompileTo(string, {person: {first: 'Alan', last: 'Johnson'}}, 'Alan Johnson', 'should work with block params');
     });
     it('with with block params should not change context', function() {
       var string = '{{#with foo as |bar|}}{{foo}}{{bar}}{{baz}}/{{.}}{{/with}}/{{foo}}{{bar}}{{baz}}';
-      shouldCompileTo(string, {foo: 'a', bar: 'b', baz: 'c', toString: function() { return 'd'; }}, 'aac/d/abc');
+      shouldCompileTo(string, {foo: 'a', bar: 'b', baz: 'c', toString: function() { return 'd'; }}, 'aac/d/abc', 'should not change context when using block params');
     });
     it('with with block params should nest', function() {
       var string = '{{#with foo as |bar|}}{{#with bar as |baz|}}{{foo}}{{bar}}{{baz}}{{/with}}/{{foo}}{{bar}}{{baz}}{{/with}}/{{foo}}{{bar}}{{baz}}';
-      shouldCompileTo(string, {foo: 'a'}, 'aaa/aa/a');
+      shouldCompileTo(string, {foo: 'a'}, 'aaa/aa/a', 'should work with nested block params');
     });
   });
 

--- a/spec/builtins.js
+++ b/spec/builtins.js
@@ -48,16 +48,20 @@ describe('builtin helpers', function() {
       shouldCompileTo(string, {}, 'Person is not present');
     });
     it('with should change context', function() {
-      var string = '{{#with foo}}{{.}}/{{foo}}{{bar}}{{baz}}{{/with}}';
-      shouldCompileTo(string, {foo: 'a', bar: 'b', baz: 'c'}, 'a/');
+      var string = '{{#with foo}}{{foo}}{{bar}}{{baz}}/{{.}}{{/with}}/{{foo}}{{bar}}{{baz}}';
+      shouldCompileTo(string, {foo: 'a', bar: 'b', baz: 'c'}, '/a/abc');
     });
     it('with with block params', function() {
       var string = '{{#with person as |p|}}{{p.first}} {{p.last}}{{/with}}';
       shouldCompileTo(string, {person: {first: 'Alan', last: 'Johnson'}}, 'Alan Johnson');
     });
     it('with with block params should not change context', function() {
-      var string = '{{#with foo as |bar|}}{{.}}/{{foo}}{{bar}}{{baz}}{{/with}}';
-      shouldCompileTo(string, {foo: 'a', bar: 'b', baz: 'c', toString: function() { return 'd'; }}, 'd/aac');
+      var string = '{{#with foo as |bar|}}{{foo}}{{bar}}{{baz}}/{{.}}{{/with}}/{{foo}}{{bar}}{{baz}}';
+      shouldCompileTo(string, {foo: 'a', bar: 'b', baz: 'c', toString: function() { return 'd'; }}, 'aac/d/abc');
+    });
+    it('with with block params should nest', function() {
+      var string = '{{#with foo as |bar|}}{{#with bar as |baz|}}{{foo}}{{bar}}{{baz}}{{/with}}/{{foo}}{{bar}}{{baz}}{{/with}}/{{foo}}{{bar}}{{baz}}';
+      shouldCompileTo(string, {foo: 'a'}, 'aaa/aa/a');
     });
   });
 

--- a/spec/builtins.js
+++ b/spec/builtins.js
@@ -47,6 +47,18 @@ describe('builtin helpers', function() {
       var string = '{{#with person}}Person is present{{else}}Person is not present{{/with}}';
       shouldCompileTo(string, {}, 'Person is not present');
     });
+    it('with should change context', function() {
+      var string = '{{#with foo}}{{.}}/{{foo}}{{bar}}{{baz}}{{/with}}';
+      shouldCompileTo(string, {foo: 1, bar: 2, baz: 3}, '1/');
+    });
+    it('with with block params', function() {
+      var string = '{{#with person as |p|}}{{p.first}} {{p.last}}{{/with}}';
+      shouldCompileTo(string, {person: {first: 'Alan', last: 'Johnson'}}, 'Alan Johnson');
+    });
+    it('with with block params should not change context', function() {
+      var string = '{{#with foo as |bar|}}{{.}}/{{foo}}{{bar}}{{baz}}{{/with}}';
+      shouldCompileTo(string, {foo: 1, bar: 2, baz: 3, toString: function() { return '!'; }}, '!/113');
+    });
   });
 
   describe('#each', function() {

--- a/spec/builtins.js
+++ b/spec/builtins.js
@@ -139,25 +139,25 @@ describe('builtin helpers', function() {
     it('each should change context', function() {
       var string = '{{#each foo}}{{.}}{{bar}}{{@key}} {{@index}} {{@first}} {{@last}} {{baz}}{{/each}}';
       var hash = {foo: ['a', 'b', 'c'], bar: 'd', baz: 'e'};
-      shouldCompileTo(string, hash, 'a0 0 true false b1 1 false false c2 2 false true ');
+      shouldCompileTo(string, hash, 'a0 0 true false b1 1 false false c2 2 false true ', 'should change context');
     });
 
     it('each with block params', function() {
       var string = '{{#each goodbyes as |value index|}}{{index}}. {{value.text}}! {{#each goodbyes as |childValue childIndex|}} {{index}} {{childIndex}}{{/each}} After {{index}} {{/each}}{{index}}cruel {{world}}!';
       var hash = {goodbyes: [{text: 'goodbye'}, {text: 'Goodbye'}], world: 'world'};
-      shouldCompileTo(string, hash, '0. goodbye!  0 0 0 1 After 0 1. Goodbye!  1 0 1 1 After 1 cruel world!');
+      shouldCompileTo(string, hash, '0. goodbye!  0 0 0 1 After 0 1. Goodbye!  1 0 1 1 After 1 cruel world!', 'should work with block params');
     });
 
     it('each with block params should not change context', function() {
       var string = '{{#each foo as |bar barKey barIndex barFirst barLast|}}{{.}}{{bar}}{{barKey}} {{barIndex}} {{barFirst}} {{barLast}} {{baz}}{{/each}}';
       var hash = {foo: ['a', 'b', 'c'], bar: 'd', baz: 'e', toString: function() { return 'f'; } };
-      shouldCompileTo(string, hash, 'fa0 0 true false efb1 1 false false efc2 2 false true e');
+      shouldCompileTo(string, hash, 'fa0 0 true false efb1 1 false false efc2 2 false true e', 'should not change context when using block params');
     });
 
     it('each with block params should nest', function() {
       var string = '{{#each foo as |bar|}}{{#each bar as |baz|}}{{baz}}{{/each}}/{{/each}}';
       var hash = {foo: [ ['a', 'b', 'c'], ['d', 'e', 'f'] ] };
-      shouldCompileTo(string, hash, 'abc/def/');
+      shouldCompileTo(string, hash, 'abc/def/', 'should work with nested block params');
     });
 
     it('each object with @index', function() {

--- a/spec/builtins.js
+++ b/spec/builtins.js
@@ -160,6 +160,18 @@ describe('builtin helpers', function() {
       shouldCompileTo(string, hash, 'abc/def/', 'should work with nested block params');
     });
 
+    it('each with empty string property', function() {
+      var string = '{{#each obj}}{{.}}({{@key}} {{@index}} {{@first}} {{@last}})/{{/each}}';
+      var hash = {obj: {'': 'Please Select', 'selected': 'Selected'} };
+
+      // Object property iteration order is undefined according to ECMA spec,
+      // so we need to check both possible orders
+      // @see http://stackoverflow.com/questions/280713/elements-order-in-a-for-in-loop
+      var actual = compileWithPartials(string, hash);
+      equals(actual === 'Please Select( 0 true false)/Selected(selected 1 false true)/' ||
+             actual === 'Selected(selected 0 true false)/Please Select( 1 false true)/', true, 'should iterate over empty string property');
+    });
+
     it('each object with @index', function() {
       var string = '{{#each goodbyes}}{{@index}}. {{text}}! {{/each}}cruel {{world}}!';
       var hash = {goodbyes: {'a': {text: 'goodbye'}, b: {text: 'Goodbye'}, c: {text: 'GOODBYE'}}, world: 'world'};


### PR DESCRIPTION
Block parameter does not change current context