### PR TITLE
Bump uglify version to fix vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "source-map": "^0.1.40"
   },
   "optionalDependencies": {
-    "uglify-js": "~2.3"
+    "uglify-js": "~2.4"
   },
   "devDependencies": {
     "async": "^0.9.0",


### PR DESCRIPTION
For more information see: https://nodesecurity.io/advisories/uglifyjs_incorrectly_handles_non-boolean_comparisons