### PR TITLE
Include partial name in 'undefined partial' exception message

### DIFF
--- a/lib/handlebars/base.js
+++ b/lib/handlebars/base.js
@@ -51,7 +51,7 @@ HandlebarsEnvironment.prototype = {
       extend(this.partials, name);
     } else {
       if (typeof partial === 'undefined') {
-        throw new Exception('Attempting to register a partial as undefined');
+        throw new Exception('Attempting to register a partial called `' + name + '` as undefined');
       }
       this.partials[name] = partial;
     }

--- a/lib/handlebars/base.js
+++ b/lib/handlebars/base.js
@@ -51,7 +51,7 @@ HandlebarsEnvironment.prototype = {
       extend(this.partials, name);
     } else {
       if (typeof partial === 'undefined') {
-        throw new Exception('Attempting to register a partial called `' + name + '` as undefined');
+        throw new Exception(`Attempting to register a partial called "${name}" as undefined`);
       }
       this.partials[name] = partial;
     }

--- a/spec/partials.js
+++ b/spec/partials.js
@@ -103,7 +103,7 @@ describe('partials', function() {
     shouldThrow(function() {
       var undef;
       handlebarsEnv.registerPartial('undefined_test', undef);
-    }, Handlebars.Exception, 'Attempting to register a partial called `undefined_test` as undefined');
+    }, Handlebars.Exception, 'Attempting to register a partial called "undefined_test" as undefined');
   });
 
   it('rendering template partial in vm mode throws an exception', function() {

--- a/spec/partials.js
+++ b/spec/partials.js
@@ -103,7 +103,7 @@ describe('partials', function() {
     shouldThrow(function() {
       var undef;
       handlebarsEnv.registerPartial('undefined_test', undef);
-    }, Handlebars.Exception, 'Attempting to register a partial as undefined');
+    }, Handlebars.Exception, 'Attempting to register a partial called `undefined_test` as undefined');
   });
 
   it('rendering template partial in vm mode throws an exception', function() {


### PR DESCRIPTION
My project has occasionally had production issues with undefined partials due to programmer error, but we use enough partials that figuring out what's wrong can take a bit of sleuthing.

This patch changes the exception message to include the name of the partial in the error message. This seems in keeping with the general style of the codebase (for example, see various instances in [runtime.js](/wycats/handlebars.js/blob/94c840b/lib/handlebars/runtime.js) — e.g.:
`````js
throw new Exception('The partial ' + options.name + ' could not be found');`)
````