### PR TITLE
Add promised-handlebars to "in-the-wild"-list

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -149,6 +149,7 @@ Handlebars in the Wild
 * [YUI](http://yuilibrary.com/yui/docs/handlebars/) implements a port of handlebars
 * [Swag](https://github.com/elving/swag) by [@elving](https://github.com/elving) is a growing collection of helpers for handlebars.js. Give your handlebars.js templates some swag son!
 * [DOMBars](https://github.com/blakeembrey/dombars) is a DOM-based templating engine built on the Handlebars parser and runtime
+* [promised-handlebars](https://github.com/nknapp/promised-handlebars) is a wrapper for Handlebars that allows helpers to return Promises.
 
 External Resources
 ------------------


### PR DESCRIPTION
I would like to add this project to the "in-the-wild"-list started this project to support a couple of other projects of mine. It hasn't gotten much attention yet, but it works pretty well for me and may be interesting for others that need async capabillities in Handlebars.