### PR TITLE
Update uglify-js to avoid vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "source-map": "^0.4.4"
   },
   "optionalDependencies": {
-    "uglify-js": "~2.4"
+    "uglify-js": "~2.6"
   },
   "devDependencies": {
     "aws-sdk": "^2.1.49",


### PR DESCRIPTION
The security advisory https://nodesecurity.io/advisories/48 says version 2.6.0 or later of uglify-js is needed.

The tests passed with the new version.