### PR TITLE
Move uglify from optionalDependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,9 +25,6 @@
     "optimist": "^0.6.1",
     "source-map": "^0.4.4"
   },
-  "optionalDependencies": {
-    "uglify-js": "^2.6"
-  },
   "devDependencies": {
     "aws-sdk": "^2.1.49",
     "babel-loader": "^5.0.0",
@@ -53,6 +50,7 @@
     "mock-stdin": "^0.3.0",
     "mustache": "^2.1.3",
     "semver": "^5.0.1",
+    "uglify-js": "^2.6",
     "underscore": "^1.5.1",
     "webpack": "^1.12.6",
     "webpack-dev-server": "^1.12.1"


### PR DESCRIPTION
`optionalDependencies` causes `uglify-js` to be fetched every time NPM installs `handlebars` or any modules that depend on it, which is wasted bandwidth (2MB). It should be in `devDependencies` instead. cc @kpdecker  