### PR TITLE
Preserve License info in Closure Compiler

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,7 +22,7 @@ module.exports = function(grunt) {
       dist: {
         options: {
           processContent: function(content) {
-            return grunt.template.process('/*!\n\n <%= pkg.name %> v<%= pkg.version %>\n\n<%= grunt.file.read("LICENSE") %>\n@license\n*/\n')
+            return grunt.template.process('/**!\n\n @license\n <%= pkg.name %> v<%= pkg.version %>\n\n<%= grunt.file.read("LICENSE") %>\n*/\n')
                 + content;
           }
         },


### PR DESCRIPTION
To preserve license info in Closure Compiler the license has to be JSDoc-comment (not simple comment) and have @license before license text