### PR TITLE
Update lookup.js

### DIFF
--- a/lib/handlebars/helpers/lookup.js
+++ b/lib/handlebars/helpers/lookup.js
@@ -1,8 +1,13 @@
 export default function(instance) {
   instance.registerHelper('lookup', function(obj) {
     var args = Array.prototype.slice.call(arguments, 1);
-    while (args.length > 1) {
-      obj = obj[args.shift()];
+    try {
+      while (args.length > 1) {
+        obj = obj[args.shift()];
+      }
+    }
+    catch(e) {
+      return undefined;
     }
     return obj;
   });

--- a/lib/handlebars/helpers/lookup.js
+++ b/lib/handlebars/helpers/lookup.js
@@ -1,5 +1,9 @@
 export default function(instance) {
-  instance.registerHelper('lookup', function(obj, field) {
-    return obj && obj[field];
+  instance.registerHelper('lookup', function(obj) {
+    var args = Array.prototype.slice.call(arguments, 1);
+    while (args.length > 1) {
+      obj = obj[args.shift()];
+    }
+    return obj;
   });
 }

--- a/lib/handlebars/helpers/lookup.js
+++ b/lib/handlebars/helpers/lookup.js
@@ -1,12 +1,8 @@
 export default function(instance) {
   instance.registerHelper('lookup', function(obj) {
     let args = Array.prototype.slice.call(arguments, 1);
-    try {
-      while (args.length > 1) {
-        obj = obj[args.shift()];
-      }
-    } catch (e) {
-      obj = undefined;
+    while (args.length > 1) {
+      obj = obj && obj[args.shift()];
     }
     return obj;
   });

--- a/lib/handlebars/helpers/lookup.js
+++ b/lib/handlebars/helpers/lookup.js
@@ -1,7 +1,7 @@
 export default function(instance) {
   instance.registerHelper('lookup', function(obj) {
     let args = Array.prototype.slice.call(arguments, 1);
-    while (args.length > 1) {
+    while (obj && args.length > 1) {
       obj = obj && obj[args.shift()];
     }
     return obj;

--- a/lib/handlebars/helpers/lookup.js
+++ b/lib/handlebars/helpers/lookup.js
@@ -1,13 +1,12 @@
 export default function(instance) {
   instance.registerHelper('lookup', function(obj) {
-    var args = Array.prototype.slice.call(arguments, 1);
+    let args = Array.prototype.slice.call(arguments, 1);
     try {
       while (args.length > 1) {
         obj = obj[args.shift()];
       }
-    }
-    catch(e) {
-      return undefined;
+    } catch (e) {
+      obj = undefined;
     }
     return obj;
   });


### PR DESCRIPTION
Makes it possible to use lookup with multiple arguments, eg: `{{lookup obj 'foo' 'bar' 'baz'}}` instead of `{{lookup (lookup (lookup obj 'foo') 'bar') 'baz'}}`
