### PR TITLE
Ensure that existing blockParams and depths are respected on dupe programs

### DIFF
--- a/lib/handlebars/compiler/javascript-compiler.js
+++ b/lib/handlebars/compiler/javascript-compiler.js
@@ -701,11 +701,11 @@ JavaScriptCompiler.prototype = {
       child = children[i];
       compiler = new this.compiler();    // eslint-disable-line new-cap
 
-      let index = this.matchExistingProgram(child);
+      let existing = this.matchExistingProgram(child);
 
-      if (index == null) {
+      if (existing == null) {
         this.context.programs.push('');     // Placeholder to prevent name conflicts for nested children
-        index = this.context.programs.length;
+        let index = this.context.programs.length;
         child.index = index;
         child.name = 'program' + index;
         this.context.programs[index] = compiler.compile(child, options, this.context, !this.precompile);
@@ -714,12 +714,14 @@ JavaScriptCompiler.prototype = {
 
         this.useDepths = this.useDepths || compiler.useDepths;
         this.useBlockParams = this.useBlockParams || compiler.useBlockParams;
+        child.useDepths = this.useDepths;
+        child.useBlockParams = this.useBlockParams;
       } else {
-        child.index = index;
-        child.name = 'program' + index;
+        child.index = existing.index;
+        child.name = 'program' + existing.index;
 
-        this.useDepths = this.useDepths || child.useDepths;
-        this.useBlockParams = this.useBlockParams || child.useBlockParams;
+        this.useDepths = this.useDepths || existing.useDepths;
+        this.useBlockParams = this.useBlockParams || existing.useBlockParams;
       }
     }
   },
@@ -727,7 +729,7 @@ JavaScriptCompiler.prototype = {
     for (let i = 0, len = this.context.environments.length; i < len; i++) {
       let environment = this.context.environments[i];
       if (environment && environment.equals(child)) {
-        return i;
+        return environment;
       }
     }
   },

--- a/spec/regressions.js
+++ b/spec/regressions.js
@@ -268,4 +268,13 @@ describe('Regressions', function() {
       ' 1. IF: John--\n'
       + ' 2. MYIF: John==\n');
   });
+
+  it('GH-1186: Support block params for existing programs', function() {
+    var string =
+        '{{#*inline "test"}}{{> @partial-block }}{{/inline}}'
+      + '{{#>test }}{{#each listOne as |item|}}{{ item }}{{/each}}{{/test}}'
+      + '{{#>test }}{{#each listTwo as |item|}}{{ item }}{{/each}}{{/test}}';
+
+    shouldCompileTo(string, { listOne: ['a'], listTwo: ['b']}, 'ab', '');
+  });
 });


### PR DESCRIPTION
Fixes #1186 

I'm opening this partly just to help identify the problem, my knowledge of the internals of `handlebars.js` is non-existent and there may well be more desirable ways to fix this problem.

I believe underlying cause is that the previous `compiler.useBlockParams` is not respected for any subsequent existing programs that are matched. I've just set/stashed/slashed/hacked the value on to `child` environment, but this is the part that may need to be done differently.

Question - how much performance does matching/re-using the existing programs save? (Just curious)