### PR TITLE
Fix test failure caused by yargs

### DIFF
--- a/bin/handlebars
+++ b/bin/handlebars
@@ -102,12 +102,7 @@ var yargs = require('yargs')
       }
     })
 
-    .wrap(120)
-    .check(function(argv) {
-      if (argv.version) {
-        return;
-      }
-    });
+    .wrap(120);
 
 
 var argv = yargs.argv;


### PR DESCRIPTION
In yargs 3.2, any non-truthy return value from check will fail: https://github.com/yargs/yargs/blob/master/CHANGELOG.md#302-20150213-1650-0000
It appears that this check is no longer necessary as the other contents of the check callback no longer exist: https://github.com/wycats/handlebars.js/commit/2e7a3bd70223c0e532a24290c7d817b951354541#diff-2aff13863648736946e83d70c5e63520L86
It appears the build failed for PR #1180, not sure why it was merged