### PR TITLE
Upgrade jison to 0.4.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "grunt-saucelabs": "8.x",
     "grunt-webpack": "^1.0.8",
     "istanbul": "github:kpdecker/istanbul",
-    "jison": "^0.4.17",
+    "jison": "0.4.16",
     "mocha": "~1.20.0",
     "mock-stdin": "^0.3.0",
     "mustache": "^2.1.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "grunt-saucelabs": "8.x",
     "grunt-webpack": "^1.0.8",
     "istanbul": "github:kpdecker/istanbul",
-    "jison": "~0.3.0",
+    "jison": "^0.4.17",
     "mocha": "~1.20.0",
     "mock-stdin": "^0.3.0",
     "mustache": "^2.1.3",


### PR DESCRIPTION
Upgrades the jison dependency to 0.4.16. Version 0.4.17 (latest as now) does not pass in tests

The main reason for the upgrade is to allow building the parser at windows environments.

Another benefit is the reduced handlebars.js file. From 544Kb to 509Kb