### PR TITLE
Update definition of BlockStatement.path

### DIFF
--- a/docs/compiler-api.md
+++ b/docs/compiler-api.md
@@ -66,7 +66,7 @@ interface MustacheStatement <: Statement {
 
 interface BlockStatement <: Statement {
     type: "BlockStatement";
-    path: PathExpression;
+    path: PathExpression | Literal;
     params: [ Expression ];
     hash: Hash;
 


### PR DESCRIPTION
As pointed in https://github.com/wycats/handlebars.js/issues/1237 BlockStatement.path accepts in practice PathExpression or Literal.  
Updates its definition to reflect this fact