### PR TITLE
Walk up data frames for nested @partial-block

### DIFF
--- a/lib/handlebars/runtime.js
+++ b/lib/handlebars/runtime.js
@@ -197,7 +197,12 @@ export function wrapProgram(container, i, fn, data, declaredBlockParams, blockPa
 export function resolvePartial(partial, context, options) {
   if (!partial) {
     if (options.name === '@partial-block') {
-      partial = options.data['partial-block'];
+      let data = options.data;
+      while (data['partial-block'] === noop) {
+        data = data._parent;
+      }
+      partial = data['partial-block'];
+      data['partial-block'] = noop;
     } else {
       partial = options.partials[options.name];
     }

--- a/spec/partials.js
+++ b/spec/partials.js
@@ -270,6 +270,20 @@ describe('partials', function() {
         true,
         'success');
     });
+    it('should render nested partial blocks', function() {
+      shouldCompileToWithPartials(
+        '.template-start.{{#> outer}}{{value}}{{/outer}}.template-end.',
+        [
+          {value: 'success'},
+          {},
+          {
+            outer: '.outer-start.{{#> nested}}.outer-partial-block-start.{{> @partial-block}}.outer-partial-block-end.{{/nested}}.outer-end.',
+            nested: '.nested-start.{{> @partial-block}}.nested-end.'
+          }
+        ],
+        true,
+        '.template-start..outer-start..nested-start..outer-partial-block-start.success.outer-partial-block-end..nested-end..outer-end..template-end.');
+    });
   });
 
   describe('inline partials', function() {

--- a/spec/partials.js
+++ b/spec/partials.js
@@ -272,17 +272,17 @@ describe('partials', function() {
     });
     it('should render nested partial blocks', function() {
       shouldCompileToWithPartials(
-        '.template-start.{{#> outer}}{{value}}{{/outer}}.template-end.',
+        '<template>{{#> outer}}{{value}}{{/outer}}</template>',
         [
           {value: 'success'},
           {},
           {
-            outer: '.outer-start.{{#> nested}}.outer-partial-block-start.{{> @partial-block}}.outer-partial-block-end.{{/nested}}.outer-end.',
-            nested: '.nested-start.{{> @partial-block}}.nested-end.'
+            outer: '<outer>{{#> nested}}<outer-block>{{> @partial-block}}</outer-block>{{/nested}}</outer>',
+            nested: '<nested>{{> @partial-block}}</nested>'
           }
         ],
         true,
-        '.template-start..outer-start..nested-start..outer-partial-block-start.success.outer-partial-block-end..nested-end..outer-end..template-end.');
+        '<template><outer><nested><outer-block>success</outer-block></nested></outer></template>');
     });
   });
 

--- a/spec/partials.js
+++ b/spec/partials.js
@@ -323,6 +323,15 @@ describe('partials', function() {
         true,
         'success');
     });
+    it('should render nested inline partials', function() {
+      shouldCompileToWithPartials(
+        '{{#*inline "outer"}}{{#>inner}}<outer-block>{{>@partial-block}}</outer-block>{{/inner}}{{/inline}}' +
+        '{{#*inline "inner"}}<inner>{{>@partial-block}}</inner>{{/inline}}' +
+        '{{#>outer}}{{value}}{{/outer}}',
+        [{value: 'success'}, {}, {}],
+        true,
+        '<inner><outer-block>success</outer-block></inner>');
+    });
   });
 
   it('should pass compiler flags', function() {


### PR DESCRIPTION
The root cause of #1218 is that `invokePartial` creates a stack of data frames
for nested partial blocks, but `resolvePartial` always uses the value at top of
the stack without "popping" it. The result is an infinite recursive loop, as
references to `@partial-block` in the partial at the top of the stack resolve to
itself.

So, walk up the stack of data frames when evaluating. This is accomplished by
1) setting the `partial-block` property to `noop` after use and
2) using `_parent['partial-block']` if `partial-block` is `noop`

Fix #1218