### PR TITLE
Fix build in windows - WIP

### DIFF
--- a/tasks/test.js
+++ b/tasks/test.js
@@ -5,13 +5,14 @@ module.exports = function(grunt) {
   grunt.registerTask('test:bin', function() {
     var done = this.async();
 
-    childProcess.exec('./bin/handlebars -a spec/artifacts/empty.handlebars', function(err, stdout) {
+    childProcess.exec('node ./bin/handlebars -a spec/artifacts/empty.handlebars', function(err, stdout) {
       if (err) {
         throw err;
       }
 
-      var expected = fs.readFileSync('./spec/expected/empty.amd.js');
-      if (stdout.toString() !== expected.toString()) {
+      var expected = fs.readFileSync('./spec/expected/empty.amd.js').toString().replace(/\r\n/g, '\n');
+
+      if (stdout.toString() !== expected) {
         throw new Error('Expected binary output differed:\n\n"' + stdout + '"\n\n"' + expected + '"');
       }
 


### PR DESCRIPTION
This PR fixes two issues building on windows.

To run the binary is necessary to use `node ./bin/handlebars` instead of  `./bin/handlebars`

The expected file is read with Windows (/r/n) line ending. Is necessary to convert to Unix line ending (/n) before compare

With this PR, build pass and tests pass but an error occurs running istanbul. Similar to https://github.com/gotwarlost/istanbul/issues/500

Running "test:cov" task
D:\repositories\handlebars.js\node_modules\.bin\istanbul:4
case `uname` in
^^^^

SyntaxError: Unexpected token case
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:414:25)
    at Object.Module._extensions..js (module.js:442:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:311:12)
    at Function.Module.runMain (module.js:467:10)
    at startup (node.js:134:18)
    at node.js:961:3
Fatal error: 1 tests failed
