### PR TITLE
Fix istanbul dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "grunt-eslint": "^17.1.0",
     "grunt-saucelabs": "8.x",
     "grunt-webpack": "^1.0.8",
-    "istanbul": "github:kpdecker/istanbul",
+    "istanbul": "kpdecker/istanbul",
     "jison": "0.4.16",
     "mocha": "~1.20.0",
     "mock-stdin": "^0.3.0",


### PR DESCRIPTION
According to npm's documentation[1], dependencies on github
repositories are declared with the following syntax:
    "module": "person/module"

This commit changes the package.json syntax on istanbul's dependency,
to follow the documentation.

[1] https://docs.npmjs.com/files/package.json#github-urls