### PR TITLE
require('sys') is deprecated, using 'util' instead

### DIFF
--- a/bench/util/benchwarmer.js
+++ b/bench/util/benchwarmer.js
@@ -11,7 +11,7 @@ function BenchWarmer() {
   this.errors = {};
 }
 
-var print = require('sys').print;
+var print = require('util').print;
 
 BenchWarmer.prototype = {
   winners: function(benches) {


### PR DESCRIPTION
(node:30288) DeprecationWarning: sys is deprecated. Use util instead.

https://github.com/nodejs/node-v0.x-archive/issues/3577