### PR TITLE
Template for issues and pull-request

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,10 @@
+Before filing issues, please check the following points first:
+
+- [ ] Have a look at https://github.com/wycats/handlebars.js/blob/master/CONTRIBUTING.md
+- [ ] Read the FAQ at https://github.com/wycats/handlebars.js/blob/master/FAQ.md
+- [ ] Use the jsfiddle-template at https://jsfiddle.net/9D88g/47/ to reproduce problems or bugs
+
+This will probably help you to get a solution faster. 
+For bugs, it would be great to have a PR with a failing test-case.
+
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+Before creating a pull-request, please check https://github.com/wycats/handlebars.js/blob/master/CONTRIBUTING.md first.
+
+Generally we like to see pull requests that
+
+- [ ] Maintain the existing code style
+- [ ] Are focused on a single change (i.e. avoid large refactoring or style adjustments in untouched code if not the primary goal of the pull request)
+- [ ] Have good commit messages
+- [ ] Have tests
+- [ ] Don't significantly decrease the current code coverage (see coverage/lcov-report/index.html)
+
+


### PR DESCRIPTION
I have noticed that many issues are initially answered with "Could you please provide a jsfiddle to reproduce your problem". Since GitHub now supports [templates for issues and pull-requests](https://github.com/blog/2111-issue-and-pull-request-templates), I thought it might be a good idea to create a template that asks for a jsfiddle from the start and points to the template directly.
This saves the time for collaborators and probably leads to a faster solution for the reporter.

I have provided a pull-request-template as well and it is mostly copied from the contributing-guide.



