### PR TITLE
add license comment with uglifyjs

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -19,17 +19,6 @@ module.exports = function(grunt) {
     clean: ['tmp', 'dist', 'lib/handlebars/compiler/parser.js'],
 
     copy: {
-      dist: {
-        options: {
-          processContent: function(content) {
-            return grunt.template.process('/**!\n\n @license\n <%= pkg.name %> v<%= pkg.version %>\n\n<%= grunt.file.read("LICENSE") %>\n*/\n')
-                + content;
-          }
-        },
-        files: [
-          {expand: true, cwd: 'dist/', src: ['*.js'], dest: 'dist/'}
-        ]
-      },
       cdnjs: {
         files: [
           {expand: true, cwd: 'dist/', src: ['*.js'], dest: 'dist/cdnjs'}
@@ -124,6 +113,7 @@ module.exports = function(grunt) {
     uglify: {
       options: {
         mangle: true,
+        banner: '/**!\n\n @license\n <%= pkg.name %> v<%= pkg.version %>\n\n<%= grunt.file.read("LICENSE") %>\n*/\n',
         compress: true,
         preserveComments: /(?:^!|@(?:license|preserve|cc_on))/
       },
@@ -210,7 +200,7 @@ module.exports = function(grunt) {
   this.registerTask('globals', ['webpack']);
   this.registerTask('tests', ['concat:tests']);
 
-  this.registerTask('release', 'Build final packages', ['eslint', 'amd', 'uglify', 'test:min', 'copy:dist', 'copy:components', 'copy:cdnjs']);
+  this.registerTask('release', 'Build final packages', ['eslint', 'amd', 'uglify', 'test:min', 'copy:components', 'copy:cdnjs']);
 
   // Load tasks from npm
   grunt.loadNpmTasks('grunt-contrib-clean');


### PR DESCRIPTION
I noticed that the `dist` files I downloaded from npmjs had multiple banners. The cause is the grunt copy task, which would happily add a license comment above a license comment.

It's a tiny waste of bandwidth, but an easy problem to fix with the uglify `banner` option. It also simplifies the build task by a few fractions of a second.