### PR TITLE
Stringify the obj when using 'strict' mode

### DIFF
--- a/lib/handlebars/runtime.js
+++ b/lib/handlebars/runtime.js
@@ -69,7 +69,7 @@ export function template(templateSpec, env) {
   let container = {
     strict: function(obj, name) {
       if (!(name in obj)) {
-        throw new Exception('"' + name + '" not defined in ' + obj);
+        throw new Exception('"' + name + '" not defined in ' + JSON.stringify(obj));
       }
       return obj[name];
     },


### PR DESCRIPTION
when using 'strict' mode, message just got a [object Object], rather than a stringify json.