### PR TITLE
WIP: Possible fix for #1252: Using @partial-block twice in a template not possible

### DIFF
--- a/lib/handlebars/runtime.js
+++ b/lib/handlebars/runtime.js
@@ -210,12 +210,7 @@ export function wrapProgram(container, i, fn, data, declaredBlockParams, blockPa
 export function resolvePartial(partial, context, options) {
   if (!partial) {
     if (options.name === '@partial-block') {
-      let data = options.data;
-      while (data['partial-block'] === noop) {
-        data = data._parent;
-      }
-      partial = data['partial-block'];
-      data['partial-block'] = noop;
+      partial = options.data['partial-block'];
     } else {
       partial = options.partials[options.name];
     }
@@ -228,6 +223,8 @@ export function resolvePartial(partial, context, options) {
 }
 
 export function invokePartial(partial, context, options) {
+  // Use the current closure context to save the partial-block if this partial
+  const currentPartialBlock = options.data && options.data['partial-block'];
   options.partial = true;
   if (options.ids) {
     options.data.contextPath = options.ids[0] || options.data.contextPath;
@@ -236,10 +233,17 @@ export function invokePartial(partial, context, options) {
   let partialBlock;
   if (options.fn && options.fn !== noop) {
     options.data = createFrame(options.data);
-    partialBlock = options.data['partial-block'] = options.fn;
-
-    if (partialBlock.partials) {
-      options.partials = Utils.extend({}, options.partials, partialBlock.partials);
+    // Wrapper function to get access to currentPartialBlock from the closure
+    let fn = options.fn;
+    partialBlock = options.data['partial-block'] = function partialBlockWrapper(context, options) {
+      // Restore the partial-block from the closure for the execution of the block
+      // i.e. the part inside the block of the partial call.
+      options.data = createFrame(options.data);
+      options.data['partial-block'] = currentPartialBlock;
+      return fn(context, options);
+    };
+    if (fn.partials) {
+      options.partials = Utils.extend({}, options.partials, fn.partials);
     }
   }
 

--- a/spec/partials.js
+++ b/spec/partials.js
@@ -249,6 +249,13 @@ describe('partials', function() {
         true,
         'success');
     });
+    it('should be able to render the partial-block twice', function() {
+      shouldCompileToWithPartials(
+          '{{#> dude}}success{{/dude}}',
+          [{}, {}, {dude: '{{> @partial-block }} {{> @partial-block }}'}],
+          true,
+          'success success');
+    });
     it('should render block from partial with context', function() {
       shouldCompileToWithPartials(
         '{{#> dude}}{{value}}{{/dude}}',

--- a/spec/partials.js
+++ b/spec/partials.js
@@ -263,6 +263,32 @@ describe('partials', function() {
         true,
         'success');
     });
+    it('should allow the #each-helper to be used along with partial-blocks', function() {
+      shouldCompileToWithPartials(
+        '<template>{{#> list value}}value = {{.}}{{/list}}</template>',
+        [
+          {value: ['a', 'b', 'c']},
+          {},
+          {
+            list: '<list>{{#each .}}<item>{{> @partial-block}}</item>{{/each}}</list>'
+          }
+        ],
+        true,
+        '<template><list><item>value = a</item><item>value = b</item><item>value = c</item></list></template>');
+    });
+    it('should render block from partial with context (twice)', function() {
+      shouldCompileToWithPartials(
+          '{{#> dude}}{{value}}{{/dude}}',
+          [
+            {context: {value: 'success'}},
+            {},
+            {
+              dude: '{{#with context}}{{> @partial-block }} {{> @partial-block }}{{/with}}'
+            }
+          ],
+          true,
+          'success success');
+    });
     it('should render block from partial with context', function() {
       shouldCompileToWithPartials(
         '{{#> dude}}{{../context/value}}{{/dude}}',
@@ -290,6 +316,50 @@ describe('partials', function() {
         ],
         true,
         '<template><outer><nested><outer-block>success</outer-block></nested></outer></template>');
+    });
+    it('should render nested partial blocks at different nesting levels', function() {
+      shouldCompileToWithPartials(
+        '<template>{{#> outer}}{{value}}{{/outer}}</template>',
+        [
+          {value: 'success'},
+          {},
+          {
+            outer: '<outer>{{#> nested}}<outer-block>{{> @partial-block}}</outer-block>{{/nested}}{{> @partial-block}}</outer>',
+            nested: '<nested>{{> @partial-block}}</nested>'
+          }
+        ],
+        true,
+        '<template><outer><nested><outer-block>success</outer-block></nested>success</outer></template>');
+    });
+    it('should render nested partial blocks at different nesting levels (twice)', function() {
+      shouldCompileToWithPartials(
+        '<template>{{#> outer}}{{value}}{{/outer}}</template>',
+        [
+          {value: 'success'},
+          {},
+          {
+            outer: '<outer>{{#> nested}}<outer-block>{{> @partial-block}} {{> @partial-block}}</outer-block>{{/nested}}{{> @partial-block}}+{{> @partial-block}}</outer>',
+            nested: '<nested>{{> @partial-block}}</nested>'
+          }
+        ],
+        true,
+        '<template><outer><nested><outer-block>success success</outer-block></nested>success+success</outer></template>');
+    });
+    it('should render nested partial blocks (twice at each level)', function() {
+      shouldCompileToWithPartials(
+        '<template>{{#> outer}}{{value}}{{/outer}}</template>',
+        [
+          {value: 'success'},
+          {},
+          {
+            outer: '<outer>{{#> nested}}<outer-block>{{> @partial-block}} {{> @partial-block}}</outer-block>{{/nested}}</outer>',
+            nested: '<nested>{{> @partial-block}}{{> @partial-block}}</nested>'
+          }
+        ],
+        true,
+        '<template><outer>' +
+        '<nested><outer-block>success success</outer-block><outer-block>success success</outer-block></nested>' +
+        '</outer></template>');
     });
   });
 
@@ -338,6 +408,24 @@ describe('partials', function() {
         [{value: 'success'}, {}, {}],
         true,
         '<inner><outer-block>success</outer-block></inner>');
+    });
+    it('should render nested inline partials with partial-blocks on different nesting levels', function() {
+      shouldCompileToWithPartials(
+        '{{#*inline "outer"}}{{#>inner}}<outer-block>{{>@partial-block}}</outer-block>{{/inner}}{{>@partial-block}}{{/inline}}' +
+        '{{#*inline "inner"}}<inner>{{>@partial-block}}</inner>{{/inline}}' +
+        '{{#>outer}}{{value}}{{/outer}}',
+        [{value: 'success'}, {}, {}],
+        true,
+        '<inner><outer-block>success</outer-block></inner>success');
+    });
+    it('should render nested inline partials (twice at each level)', function() {
+      shouldCompileToWithPartials(
+        '{{#*inline "outer"}}{{#>inner}}<outer-block>{{>@partial-block}} {{>@partial-block}}</outer-block>{{/inner}}{{/inline}}' +
+        '{{#*inline "inner"}}<inner>{{>@partial-block}}{{>@partial-block}}</inner>{{/inline}}' +
+        '{{#>outer}}{{value}}{{/outer}}',
+        [{value: 'success'}, {}, {}],
+        true,
+        '<inner><outer-block>success success</outer-block><outer-block>success success</outer-block></inner>');
     });
   });
 


### PR DESCRIPTION
I've added a possible fix for this bug, but it includes some refactorings of the `@partial-block`-code. After thinking about it a lot (this is kind of a brain-twister), I've come to the conclusions that partial-blocks should be treated like function-closures:

With the example from one of the tests:

### Template 

```hbs
<template>{{#> outer}}{{value}}{{/outer}}</template>
```

### outer

```hbs
<outer>{{#> nested}}<outer-block>{{> @partial-block}}</outer-block>{{/nested}}</outer>
```

### inner

```hbs
<nested>{{> @partial-block}}</nested>
```

### Explanation

When the partial-block of the outer partial  (`<outer-block>{{> @partial-block}}</outer-block>`) is executed, the data-variable `@partial-block` of `outer` must be called. The fix does not achieve this by popping the partial-block once its been used, but by storing the partial-block in the local closure-context of the `invokePartial`-function. The partial-block for that partial is than wrapped with another function that loads the previous partial-block from the local closure-context.

I can add more explanation, once my laptop-battery has recharged. In any way, I would like to have a review of the changes. 

@lawnsea I changed some of the code from your fix for #1185, so could you review if my changes are valid in your eyes? The changes are in the branch "tmp/issue-1252".

After review, I would probably make some style changes for better readability.
