### PR TITLE
Support async #with contexts

### DIFF
--- a/lib/handlebars/helpers/with.js
+++ b/lib/handlebars/helpers/with.js
@@ -2,19 +2,29 @@ import {isEmpty, isFunction} from '../utils';
 
 export default function(instance) {
   instance.registerHelper('with', function(context, options) {
-    if (isFunction(context)) { context = context.call(this); }
-
-    let fn = options.fn;
-
-    if (!isEmpty(context)) {
-      let data = options.data;
-
-      return fn(context, {
-        data: data,
-        blockParams: [context]
-      });
+    let async;
+    if (isFunction(context) && context.length) {
+      async = context;
     } else {
-      return options.inverse(this);
+      if (isFunction(context)) { context = context.call(this); }
+      async = function(fn) {
+        return fn(context);
+      };
     }
+
+    return async.call(this, function(context) {
+      let fn = options.fn;
+
+      if (!isEmpty(context)) {
+        let data = options.data;
+
+        return fn(context, {
+          data: data,
+          blockParams: [context]
+        });
+      } else {
+        return options.inverse(this);
+      }
+    }, options.hash);
   });
 }

--- a/spec/builtins.js
+++ b/spec/builtins.js
@@ -48,6 +48,14 @@ describe('builtin helpers', function() {
       var string = '{{#with person}}{{first}} {{last}}{{/with}}';
       shouldCompileTo(string, {person: function() { return {first: 'Alan', last: 'Johnson'}; }}, 'Alan Johnson');
     });
+    it('with with async function argument', function() {
+      var string = '{{#with person}}{{first}} {{last}}{{/with}}';
+      shouldCompileTo(string, {person: function(fn) { return fn({first: 'Alan', last: 'Johnson'}); }}, 'Alan Johnson');
+    });
+    it('with with async function argument and parameters', function() {
+      var string = '{{#with person first="Alan" last="Johnson"}}{{first}} {{last}}{{/with}}';
+      shouldCompileTo(string, {person: function(fn, hash) { return fn(hash); }}, 'Alan Johnson');
+    });
     it('with with else', function() {
       var string = '{{#with person}}Person is present{{else}}Person is not present{{/with}}';
       shouldCompileTo(string, {}, 'Person is not present');


### PR DESCRIPTION
In ```{{#with context}}body{{/with}}```, when context is a function, the
functions's return value is used as the context in body.  This allows
for computed context, but not when that context is provided
asynchronously, such as when querying a database.

To support asynchronous contexts as well, check if context is a function
that takes arguments.  If it is, call it with the callback to invoke
when done as the first, and ```#with```'s hash arguments as the second
argument.  For example, with the following context function:
```
 person: function(fn) {
    fn({first: 'Alan', last: 'Johnson'});
  }
```
The template:
```
  {{#with person}}{{first}} {{last}}{{/with}}
```
will render to:
```
  Alan Johnson
```