### PR TITLE
Handle undefined arrays better

### DIFF
--- a/lib/handlebars/helpers/each.js
+++ b/lib/handlebars/helpers/each.js
@@ -36,7 +36,7 @@ export default function(instance) {
     if (context && typeof context === 'object') {
       if (isArray(context)) {
         for (let j = context.length; i < j; i++) {
-          if (i in context) {
+          if (context[i] !== undefined) {
             execIteration(i, i, i === context.length - 1);
           }
         }

--- a/spec/regressions.js
+++ b/spec/regressions.js
@@ -288,4 +288,11 @@ describe('Regressions', function() {
 
     shouldCompileTo('{{helpa length="foo"}}', [obj, helpers], 'foo');
   });
+
+  it('GH-1227: Array of undefineds', function() {
+    var array = [undefined, undefined];
+    shouldCompileTo('foo{{#each array}}{{@index}}{{.}}{{/each}}bar', {array: array}, 'foobar');
+    var array2 = new Array(2);
+    shouldCompileTo('foo{{#each array}}{{@index}}{{.}}{{/each}}bar', {array: array2}, 'foobar');
+  });
 });


### PR DESCRIPTION
Addressing issue identified in https://github.com/wycats/handlebars.js/issues/1227 with arrays that have undefined elements.

[undefined, undefined] should have the same behavior as new Array(2),
per https://github.com/wycats/handlebars.js/issues/1065


- [x] Maintain the existing code style
- [x] Are focused on a single change (i.e. avoid large refactoring or style adjustments in untouched code if not the primary goal of the pull request)
- [x] Have good commit messages
- [x] Have tests
- [x] Don't significantly decrease the current code coverage (see coverage/lcov-report/index.html)


