### PR TITLE
Fix compiler-api example

### DIFF
--- a/docs/compiler-api.md
+++ b/docs/compiler-api.md
@@ -309,7 +309,7 @@ function MyCompiler() {
 }
 MyCompiler.prototype = new Handlebars.JavaScriptCompiler();
 
-MyCompiler.prototype.nameLookup = function (parent, name, type) {
+MyCompiler.prototype.nameLookup = function(parent, name, type) {
   if (type === 'context') {
     return this.source.functionCall('helpers.lookupLowerCase', '', [parent, JSON.stringify(name)])
   } else {
@@ -318,14 +318,14 @@ MyCompiler.prototype.nameLookup = function (parent, name, type) {
 }
 
 var env = Handlebars.create();
-env.registerHelper('lookupLowerCase', function (parent, name) {
+env.registerHelper('lookupLowerCase', function(parent, name) {
   return parent[name.toLowerCase()]
 })
 
 env.JavaScriptCompiler = MyCompiler;
 
-var template = env.compile(document.getElementById('template').innerHTML);
-document.getElementById('output').innerHTML = template({
-  test: ["a", "b", "c"]
-});
+var template = env.compile('{{#each Test}}{{.}} {{/each}}');
+console.log(template({
+  test: [ "a","b","c"]
+}));
 ```

--- a/docs/compiler-api.md
+++ b/docs/compiler-api.md
@@ -296,21 +296,36 @@ The `Handlebars.JavaScriptCompiler` object has a number of methods that may be c
 - `initializeBuffer()`
     Allows for buffers other than the default string buffer to be used. Generally needs to be paired with a custom `appendToBuffer` implementation.
 
+### Example for the compiler api.
+
+This example changes all lookups of properties are performed by a helper (`lookupLowerCase`) which looks for `test` if `{{Test}}` occurs in the template. This is just to illustrate how compiler behavior can be change.
+
+There is also [a jsfiddle with this code](https://jsfiddle.net/9D88g/85/) if you want to play around with it.
+
+
 ```javascript
 function MyCompiler() {
   Handlebars.JavaScriptCompiler.apply(this, arguments);
 }
-MyCompiler.prototype = Object.create(Handlebars.JavaScriptCompiler);
+MyCompiler.prototype = new Handlebars.JavaScriptCompiler();
 
-MyCompiler.nameLookup = function(parent, name, type) {
-  if (type === 'partial') {
-    return 'MyPartialList[' + JSON.stringify(name) ']';
+MyCompiler.prototype.nameLookup = function (parent, name, type) {
+  if (type === 'context') {
+    return this.source.functionCall('helpers.lookupLowerCase', '', [parent, JSON.stringify(name)])
   } else {
     return Handlebars.JavaScriptCompiler.prototype.nameLookup.call(this, parent, name, type);
   }
-};
+}
 
 var env = Handlebars.create();
+env.registerHelper('lookupLowerCase', function (parent, name) {
+  return parent[name.toLowerCase()]
+})
+
 env.JavaScriptCompiler = MyCompiler;
-env.compile('my template');
+
+var template = env.compile(document.getElementById('template').innerHTML);
+document.getElementById('output').innerHTML = template({
+  test: ["a", "b", "c"]
+});
 ```


### PR DESCRIPTION
While trying to answer #1302, I noticed that the compiler-api example did not work in (because `nameLookup` is actually at the prototype).
This example has a jsfiddle that proves it is working.

Before creating a pull-request, please check https://github.com/wycats/handlebars.js/blob/master/CONTRIBUTING.md first.

Generally we like to see pull requests that

- [x] Maintain the existing code style
- [x] Are focused on a single change (i.e. avoid large refactoring or style adjustments in untouched code if not the primary goal of the pull request)
- [x] Have good commit messages
- [ ] Have tests (no code has been changed)
- [x] Don't significantly decrease the current code coverage (see coverage/lcov-report/index.html)


