### PR TITLE
fix string not rendered in its block

### DIFF
--- a/lib/handlebars/helpers/block-helper-missing.js
+++ b/lib/handlebars/helpers/block-helper-missing.js
@@ -5,7 +5,7 @@ export default function(instance) {
     let inverse = options.inverse,
         fn = options.fn;
 
-    if (context === true) {
+    if (context === true || (typeof context === 'string' && !inverse.hasOwnProperty('program'))) {
       return fn(this);
     } else if (context === false || context == null) {
       return inverse(this);

--- a/spec/blocks.js
+++ b/spec/blocks.js
@@ -1,4 +1,10 @@
 describe('blocks', function() {
+  it('string', function() {
+    var string = '{{#goodbye}}{{goodbye}}{{/goodbye}} {{#world}}{{world}}{{/world}}';
+    var hash = {goodbye: 'Goodbye', world: 'Complex World'};
+    shouldCompileTo(string, hash, 'Goodbye Complex World');
+  });
+
   it('array', function() {
     var string = '{{#goodbyes}}{{text}}! {{/goodbyes}}cruel {{world}}!';
     var hash = {goodbyes: [{text: 'goodbye'}, {text: 'Goodbye'}, {text: 'GOODBYE'}], world: 'world'};


### PR DESCRIPTION
When we want to check a hash is available or not, and value of hash is a string we can't get it rendered.

### Example :

**Template**
```html
<p>
    I want to say "{{#goodbye}}{{goodbye}}{{/goodbye}} {{#world}}{{world}}{{/world}}"
</p>
```

**Hash**
```javascript
{goodbye: 'Goodbye', world: 'Complex World'}
```

On v4.0.5 it will render `I want to say " "`
After applying this it will render `I want to say "Goodbye Complex World"`