### PR TITLE
Avoid duplicate "sourceMappingURL=" lines.

### DIFF
--- a/lib/precompiler.js
+++ b/lib/precompiler.js
@@ -250,9 +250,6 @@ module.exports.cli = function(opts) {
       outSourceMap: opts.map,
       inSourceMap: JSON.parse(output.map)
     });
-    if (opts.map) {
-      output.code += '\n//# sourceMappingURL=' + opts.map + '\n';
-    }
   }
 
   if (opts.map) {

--- a/spec/precompiler.js
+++ b/spec/precompiler.js
@@ -152,14 +152,14 @@ describe('precompiler', function() {
     Precompiler.cli({templates: [emptyTemplate], map: 'foo.js.map'});
 
     equal(file, 'foo.js.map');
-    equal(/sourceMappingURL=/.test(log), true);
+    equal(log.match(/sourceMappingURL=/g).length, 1);
   });
 
   it('should output map', function() {
     Precompiler.cli({templates: [emptyTemplate], min: true, map: 'foo.js.map'});
 
     equal(file, 'foo.js.map');
-    equal(/sourceMappingURL=/.test(log), true);
+    equal(log.match(/sourceMappingURL=/g).length, 1);
   });
 
   describe('#loadTemplates', function() {


### PR DESCRIPTION
Avoid duplicate // sourceMappingURL=... lines when minifying AND
generating a map. UglifyJS2 will write the line when minifying.