### PR TITLE
parser: Change suffix to use ES6 default module export

### DIFF
--- a/.istanbul.yml
+++ b/.istanbul.yml
@@ -1,2 +1,2 @@
 instrumentation:
-    excludes: ['**/spec/**']
+    excludes: ['**/spec/**', '**/handlebars/compiler/parser.js']

--- a/src/parser-prefix.js
+++ b/src/parser-prefix.js
@@ -1,1 +1,1 @@
-/* istanbul ignore next */
+// File ignored in coverage tests via setting in .istanbul.yml

--- a/src/parser-suffix.js
+++ b/src/parser-suffix.js
@@ -1,2 +1,1 @@
-exports.__esModule = true;
-exports['default'] = handlebars;
+export default handlebars;


### PR DESCRIPTION
This export will be transpiled by Babel for the `cjs` distribution, but will enable others to use a pure ES6 module distribution.

Resolves #1313 

/cc @chadhietala @mmun 
