### PR TITLE
Added watch option (-w, --watch) for the handlebars cli.

### DIFF
--- a/bin/handlebars
+++ b/bin/handlebars
@@ -95,6 +95,11 @@ var yargs = require('yargs')
         'description': 'Prints the current compiler version',
         'alias': 'version'
       },
+      'w': {
+        'type': 'boolean',
+        'description': 'Watch the input file(s)/dir(s) and perform precompilation on changes.',
+        'alias': 'watch'
+      },
 
       'help': {
         'type': 'boolean',
@@ -110,14 +115,78 @@ argv.files = argv._;
 delete argv._;
 
 var Precompiler = require('../dist/cjs/precompiler');
-Precompiler.loadTemplates(argv, function(err, opts) {
-  if (err) {
-    throw err;
-  }
+function precompile(mArgv) {
+  Precompiler.loadTemplates(mArgv ? mArgv : argv, function(err, opts) {
+    if (err) {
+      throw err;
+    }
 
-  if (opts.help || (!opts.templates.length && !opts.version)) {
-    yargs.showHelp();
-  } else {
-    Precompiler.cli(opts);
+    if (opts.help || (!opts.templates.length && !opts.version)) {
+      yargs.showHelp();
+    } else {
+      Precompiler.cli(opts);
+    }
+  });
+}
+
+const c = require('colors');
+const files = argv.files;
+const log = console.log;
+let firstTime = true;
+if (files.length && argv.w) {
+  const chokidar = require('chokidar');
+  const DS = '/'; // require('path').sep;
+  const G = '**/*.';
+  const ext = argv.e ? argv.e : 'handlebars';
+  const toWatch = [];
+  files.forEach((i, x, a) => {
+      if ( !i.endsWith(ext) ) { // is dir
+          const glob = i.endsWith(DS) ? G : `${DS}${G}`;
+          toWatch.push(i + glob + ext);
+      } else {
+          toWatch.push(i);
+      }
+  });
+  const watcher = chokidar.watch(toWatch, {ignored: /[\/\\]\./, persistent: true});
+
+  watcher
+    .on('ready', function () {
+      firstTime = false;
+      precompile();
+      log( c.magenta.bold('Initial output file:', c.white.bgMagenta(argv.f), 'is created.') );
+      log( c.blue.bold('Watching', c.white.bgBlue(files.join('  &  ')), 'for changes...') );
+    })
+    .on('add', path => {
+      log( c.green.bold('File added:'), path );
+      precompile();
+      msg();
+    })
+    .on('addDir', path => {
+      log( c.black.bold.bgGreen('Folder added:'), path );
+      precompile();
+      msg();
+    })
+    .on('unlink', path => {
+      log( c.red.bold('File removed:'), path );
+      precompile();
+      msg();
+    })
+    .on('unlinkDir', path => {
+      log( c.white.bold.bgRed('Folder removed:'), path );
+      precompile();
+      msg();
+    })
+    .on('change', path => {
+      log( c.cyan.bold('File changed:'), path );
+      precompile();
+      msg();
+    });
+} else {
+  precompile();
+}
+
+function msg() {
+  if (!firstTime) {
+    log( c.yellow.bold('Output file:', c.white.bold.bgMagenta(argv.f), 'was recreated.') );
   }
-});
+}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
   },
   "dependencies": {
     "async": "^1.4.0",
+    "chokidar": "^1.6.1",
+    "colors": "^1.1.2",
     "source-map": "^0.4.4",
     "yargs": "^3.32.0"
   },


### PR DESCRIPTION
It watches the input file(s) / dir(s), and on changes to them, it performs the precompilation all over again.
I used the 'chokidar' package for watching files and folders, and the 'color' package for outputing nice looking messages to the console.
If you don't want the ES6 stuff tell me to replace them.
