### PR TITLE
Allow partial-blocks to be executed without "options"

### DIFF
--- a/lib/handlebars/runtime.js
+++ b/lib/handlebars/runtime.js
@@ -237,7 +237,8 @@ export function invokePartial(partial, context, options) {
     options.data = createFrame(options.data);
     // Wrapper function to get access to currentPartialBlock from the closure
     let fn = options.fn;
-    partialBlock = options.data['partial-block'] = function partialBlockWrapper(context, options) {
+    partialBlock = options.data['partial-block'] = function partialBlockWrapper(context, options = {}) {
+
       // Restore the partial-block from the closure for the execution of the block
       // i.e. the part inside the block of the partial call.
       options.data = createFrame(options.data);

--- a/spec/regressions.js
+++ b/spec/regressions.js
@@ -282,4 +282,13 @@ describe('Regressions', function() {
     var string = '{{#each list}}{{#unless ./prop}}parent={{../value}} {{/unless}}{{/each}}';
     shouldCompileTo(string, { value: 'parent', list: [ null, 'a'] }, 'parent=parent parent=parent ', '');
   });
+
+  it('GH-1341: 4.0.7 release breaks {{#if @partial-block}} usage', function() {
+    var string = 'template {{>partial}} template';
+    var partials = {
+      partialWithBlock: '{{#if @partial-block}} block {{> @partial-block}} block {{/if}}',
+      partial: '{{#> partialWithBlock}} partial {{/partialWithBlock}}'
+    };
+    shouldCompileToWithPartials(string, [{}, {}, partials], true, 'template  block  partial  block  template');
+  });
 });


### PR DESCRIPTION
Closes #1341

If the @partial-block is called as parameter of a helper (like in
{{#if @partial-block}}...{{/if}}, the partialBlockWrapper is executed
without "options"-parameter. It should still work in without an error
in such a case.
