### PR TITLE
Publish valid semver task independently of the branch

### DIFF
--- a/tasks/publish.js
+++ b/tasks/publish.js
@@ -15,14 +15,22 @@ module.exports = function(grunt) {
       git.commitInfo(function(err, info) {
         grunt.log.writeln('tag: ' + info.tagName);
 
+        var files = [];
+
+        // Publish the master as "latest" and with the commit-id
         if (info.isMaster) {
+          files.push('-latest');
+          files.push('-' + info.head);
+        }
+
+        // Publish tags by their tag-name
+        if (info.tagName && semver.valid(info.tagName)) {
+          files.push('-' + info.tagName);
+        }
+
+        if (files.length > 0) {
           initSDK();
-
-          var files = ['-latest', '-' + info.head];
-          if (info.tagName && semver.valid(info.tagName)) {
-            files.push('-' + info.tagName);
-          }
-
+          grunt.log.writeln('publishing files: ' + JSON.stringify(files));
           publish(fileMap(files), done);
         } else {
           // Silently ignore for branches


### PR DESCRIPTION
This PR updates the publish tasks such that a tagged git commit (with a valid semver-tag) is published to AWS even if it is not on the master branch.
This should solve the last issue in #1312, which is that the tagged versions from the 4.x-branch are not uploaded to AWS.