### PR TITLE
Handlebars.compile() does not modify "options" anymore

### DIFF
--- a/lib/handlebars/compiler/compiler.js
+++ b/lib/handlebars/compiler/compiler.js
@@ -70,7 +70,7 @@ Compiler.prototype = {
       for (let name in knownHelpers) {
         /* istanbul ignore else */
         if (name in knownHelpers) {
-          options.knownHelpers[name] = knownHelpers[name];
+          this.options.knownHelpers[name] = knownHelpers[name];
         }
       }
     }
@@ -488,6 +488,7 @@ export function compile(input, options = {}, env) {
     throw new Exception('You must pass a string or Handlebars AST to Handlebars.compile. You passed ' + input);
   }
 
+  options = Object.assign({}, options);
   if (!('data' in options)) {
     options.data = true;
   }

--- a/spec/compiler.js
+++ b/spec/compiler.js
@@ -73,6 +73,18 @@ describe('compiler', function() {
     it('can pass through an empty string', function() {
       equal(Handlebars.compile('')(), '');
     });
+
+    it('should not modify the options.data property(GH-1327)', function() {
+      var options = {data: [{a: 'foo'}, {a: 'bar'}]};
+      Handlebars.compile('{{#each data}}{{@index}}:{{a}} {{/each}}', options)();
+      equal(JSON.stringify(options, 0, 2), JSON.stringify({data: [{a: 'foo'}, {a: 'bar'}]}, 0, 2));
+    });
+
+    it('should not modify the options.knownHelpers property(GH-1327)', function() {
+      var options = {knownHelpers: {}};
+      Handlebars.compile('{{#each data}}{{@index}}:{{a}} {{/each}}', options)();
+      equal(JSON.stringify(options, 0, 2), JSON.stringify({knownHelpers: {}}, 0, 2));
+    });
   });
 
   describe('#precompile', function() {


### PR DESCRIPTION
Fixes #1327

- This commit creates a shallow copy of the "options" passed to
  Handlebars.compile() in order to prevent modifications
- Note that "new Handlebars.Compiler().compile(..., options)" still
  modify the options object. This might change in the future, if
  anybody needs a fix for that.

