### PR TITLE
Fix broken header tag (markdown)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ The `grunt dev` implements watching for tests and allows for in browser testing 
 If you notice any problems, please report them to the GitHub issue tracker at
 [http://github.com/wycats/handlebars.js/issues](http://github.com/wycats/handlebars.js/issues).
 
-##Running Tests
+## Running Tests
 
 To run tests locally, first install all dependencies.
 ```sh


### PR DESCRIPTION
The # was too close to the header text so that the CONTRIBUTING.md did not show properly in the GitHub UI.

Thanks for the great toolkit.