### PR TITLE
Gracefully handle missing uglify-js dependency

### DIFF
--- a/lib/precompiler.js
+++ b/lib/precompiler.js
@@ -4,7 +4,7 @@ import fs from 'fs';
 import * as Handlebars from './handlebars';
 import {basename} from 'path';
 import {SourceMapConsumer, SourceNode} from 'source-map';
-import uglify from 'uglify-js';
+
 
 module.exports.loadTemplates = function(opts, callback) {
   loadStrings(opts, function(err, strings) {
@@ -235,7 +235,6 @@ module.exports.cli = function(opts) {
     }
   }
 
-
   if (opts.map) {
     output.add('\n//# sourceMappingURL=' + opts.map + '\n');
   }
@@ -244,12 +243,7 @@ module.exports.cli = function(opts) {
   output.map = output.map + '';
 
   if (opts.min) {
-    output = uglify.minify(output.code, {
-      fromString: true,
-
-      outSourceMap: opts.map,
-      inSourceMap: JSON.parse(output.map)
-    });
+    output = minify(output, opts.map);
   }
 
   if (opts.map) {
@@ -270,4 +264,34 @@ function arrayCast(value) {
     value = [value];
   }
   return value;
+}
+
+/**
+ * Run uglify to minify the compiled template, if uglify exists in the dependencies.
+ *
+ * We are using `require` instead of `import` here, because es6-modules do not allow
+ * dynamic imports and uglify-js is an optional dependency. Since we are inside NodeJS here, this
+ * should not be a problem.
+ *
+ * @param {string} output the compiled template
+ * @param {string} sourceMapFile the file to write the source map to.
+ */
+function minify(output, sourceMapFile) {
+  try {
+    // Try to resolve uglify-js in order to see if it does exist
+    require.resolve('uglify-js');
+  } catch (e) {
+    if (e.code !== 'MODULE_NOT_FOUND') {
+      // Something else seems to be wrong
+      throw e;
+    }
+    // it does not exist!
+    console.error('Code minimization is disabled due to missing uglify-js dependency');
+    return output;
+  }
+  return require('uglify-js').minify(output.code, {
+    fromString: true,
+    outSourceMap: sourceMapFile,
+    inSourceMap: JSON.parse(output.map)
+  });
 }


### PR DESCRIPTION
closes #1391

uglify-js is an optional dependency and should be treated as such.
This commit gracefully handles MODULE_NOT_FOUND errors while loading
uglify.
