### PR TITLE
Update jsfiddle-link to a template using 4.0.11

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,4 +96,4 @@ After this point the handlebars site needs to be updated to point to the new ver
 [generator-release]: https://github.com/walmartlabs/generator-release
 [pull-request]: https://github.com/wycats/handlebars.js/pull/new/master
 [issue]: https://github.com/wycats/handlebars.js/issues/new
-[jsfiddle]: https://jsfiddle.net/9D88g/113/
+[jsfiddle]: https://jsfiddle.net/9D88g/180/


### PR DESCRIPTION
Update the jsfiddle link after publish of 4.0.11. The new jsfiddle does not work yet, because the cdn has not caught 4.0.11 yet.