### PR TITLE
Webpack upgrade

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 /* eslint-disable no-process-env */
 module.exports = function(grunt) {
 
@@ -46,12 +48,16 @@ module.exports = function(grunt) {
     babel: {
       options: {
         sourceMaps: 'inline',
-        loose: ['es6.modules'],
+        presets: [
+          ['env', { loose: true }]
+        ],
         auxiliaryCommentBefore: 'istanbul ignore next'
       },
       amd: {
         options: {
-          modules: 'amd'
+          presets: [
+            ['env', { modules: 'amd' }]
+          ]
         },
         files: [{
           expand: true,
@@ -63,7 +69,9 @@ module.exports = function(grunt) {
 
       cjs: {
         options: {
-          modules: 'common'
+          presets: [
+            ['env', { modules: 'commonjs' }]
+          ]
         },
         files: [{
           cwd: 'lib/',
@@ -73,19 +81,17 @@ module.exports = function(grunt) {
         }]
       }
     },
+
     webpack: {
       options: {
         context: __dirname,
-        module: {
-          loaders: [
-            // the optional 'runtime' transformer tells babel to require the runtime instead of inlining it.
-            { test: /\.jsx?$/, exclude: /node_modules/, loader: 'babel-loader?optional=runtime&loose=es6.modules&auxiliaryCommentBefore=istanbul%20ignore%20next' }
-          ]
-        },
         output: {
-          path: 'dist/',
+          path: path.join(__dirname, 'dist'),
           library: 'Handlebars',
           libraryTarget: 'umd'
+        },
+        module: {
+          noParse: [ /parser\.js$/ ]
         }
       },
       handlebars: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -51,6 +51,9 @@ module.exports = function(grunt) {
         presets: [
           ['env', { loose: true }]
         ],
+        plugins: [
+          'add-module-exports'
+        ],
         auxiliaryCommentBefore: 'istanbul ignore next'
       },
       amd: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -48,9 +48,6 @@ module.exports = function(grunt) {
     babel: {
       options: {
         sourceMaps: 'inline',
-        presets: [
-          ['env', { loose: true }]
-        ],
         plugins: [
           'add-module-exports'
         ],
@@ -59,7 +56,7 @@ module.exports = function(grunt) {
       amd: {
         options: {
           presets: [
-            ['env', { modules: 'amd' }]
+            ['env', { modules: 'amd', loose: true }]
           ]
         },
         files: [{
@@ -73,7 +70,7 @@ module.exports = function(grunt) {
       cjs: {
         options: {
           presets: [
-            ['env', { modules: 'commonjs' }]
+            ['env', { modules: 'commonjs', loose: true }]
           ]
         },
         files: [{
@@ -98,13 +95,13 @@ module.exports = function(grunt) {
         }
       },
       handlebars: {
-        entry: './lib/handlebars.js',
+        entry: './dist/cjs/handlebars.js',
         output: {
           filename: 'handlebars.js'
         }
       },
       runtime: {
-        entry: './lib/handlebars.runtime.js',
+        entry: './dist/cjs/handlebars.runtime.js',
         output: {
           filename: 'handlebars.runtime.js'
         }

--- a/lib/handlebars/helpers/each.js
+++ b/lib/handlebars/helpers/each.js
@@ -42,7 +42,7 @@ export default function(instance) {
       });
     }
 
-    if (context && typeof context === 'object') {
+    if (context && /* istanbul ignore next */ typeof context === 'object') {
       if (isArray(context)) {
         for (let j = context.length; i < j; i++) {
           if (i in context) {

--- a/package.json
+++ b/package.json
@@ -30,13 +30,15 @@
   },
   "devDependencies": {
     "aws-sdk": "^2.1.49",
-    "babel-loader": "^5.0.0",
+    "babel-core": "^6.26.0",
+    "babel-loader": "^7.1.2",
+    "babel-preset-env": "^1.6.1",
     "babel-runtime": "^5.1.10",
     "benchmark": "~1.0",
     "dustjs-linkedin": "^2.0.2",
     "eco": "~1.1.0-rc-3",
     "grunt": "~0.4.1",
-    "grunt-babel": "^5.0.0",
+    "grunt-babel": "^7.0.0",
     "grunt-cli": "~0.1.10",
     "grunt-contrib-clean": "0.x",
     "grunt-contrib-concat": "0.x",
@@ -47,7 +49,7 @@
     "grunt-contrib-watch": "0.x",
     "grunt-eslint": "^20.1.0",
     "grunt-saucelabs": "8.x",
-    "grunt-webpack": "^1.0.8",
+    "grunt-webpack": "^3.0.2",
     "istanbul": "^0.3.0",
     "jison": "~0.3.0",
     "mocha": "~1.20.0",
@@ -55,8 +57,8 @@
     "mustache": "^2.1.3",
     "semver": "^5.0.1",
     "underscore": "^1.5.1",
-    "webpack": "^1.12.6",
-    "webpack-dev-server": "^1.12.1"
+    "webpack": "^3.10.0",
+    "webpack-dev-server": "^2.9.7"
   },
   "main": "lib/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "aws-sdk": "^2.1.49",
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",
+    "babel-plugin-add-module-exports": "^0.2.1",
     "babel-preset-env": "^1.6.1",
     "babel-runtime": "^5.1.10",
     "benchmark": "~1.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "aws-sdk": "^2.1.49",
     "babel-core": "^6.26.0",
+    "babel-istanbul": "^0.12.2",
     "babel-loader": "^7.1.2",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-preset-env": "^1.6.1",
@@ -51,7 +52,6 @@
     "grunt-eslint": "^20.1.0",
     "grunt-saucelabs": "8.x",
     "grunt-webpack": "^3.0.2",
-    "istanbul": "^0.3.0",
     "jison": "~0.3.0",
     "mocha": "~1.20.0",
     "mock-stdin": "^0.3.0",

--- a/tasks/test.js
+++ b/tasks/test.js
@@ -42,7 +42,7 @@ module.exports = function(grunt) {
   grunt.registerTask('test:cov', function() {
     var done = this.async();
 
-    var runner = childProcess.fork('node_modules/istanbul/lib/cli.js', ['cover', '--source-map', '--', './spec/env/runner.js'], {stdio: 'inherit'});
+    var runner = childProcess.fork('node_modules/babel-istanbul/lib/cli.js', ['cover', '--source-map', '--', './spec/env/runner.js'], {stdio: 'inherit'});
     runner.on('close', function(code) {
       if (code != 0) {
         grunt.fatal(code + ' tests failed');
@@ -65,7 +65,7 @@ module.exports = function(grunt) {
   grunt.registerTask('test:check-cov', function() {
     var done = this.async();
 
-    var runner = childProcess.fork('node_modules/istanbul/lib/cli.js', ['check-coverage', '--statements', '100', '--functions', '100', '--branches', '100', '--lines 100'], {stdio: 'inherit'});
+    var runner = childProcess.fork('node_modules/babel-istanbul/lib/cli.js', ['check-coverage', '--statements', '100', '--functions', '100', '--branches', '100', '--lines 100'], {stdio: 'inherit'});
     runner.on('close', function(code) {
       if (code != 0) {
         grunt.fatal('Coverage check failed: ' + code);


### PR DESCRIPTION
Pull request to upgrade webpack and babel to respective latest versions. All test cases are working. 

There is an issue with coverage. Istanbul doesn't support ES6-Babel properly, we will have to use either [babel-istanbul](https://github.com/jmcriffey/babel-istanbul) or [isparta](https://github.com/douglasduteil/isparta). Since master branch is using a custom fork of istanbul, I'm letting you decide on how to proceed with it. 

Another way to handle is, running test cases on original source rather than the babel generated one. If we are going to do that, then we don't need grunt-babel, we will be able to use babel-loader with webpack to generate just the dist files we need, rather than exporting all transpiled sources.

Relates to: #1386 ,  #1399 , 
