### PR TITLE
#1390 Added runtimeModuleName cli variable, defaults to the previous value of handlebars.runtime

### DIFF
--- a/bin/handlebars
+++ b/bin/handlebars
@@ -24,7 +24,7 @@ var optimist = require('optimist')
       },
       'h': {
         'type': 'string',
-        'description': 'Path to handlebar.js (only valid for amd-style)',
+        'description': 'Path to Handlebars module (only valid for amd-style)',
         'alias': 'handlebarPath',
         'default': ''
       },
@@ -94,6 +94,12 @@ var optimist = require('optimist')
         'type': 'boolean',
         'description': 'Prints the current compiler version',
         'alias': 'version'
+      },
+      'runtime': {
+        'type': 'string',
+        'description': 'Path to the handlebars runtime from the module folder, used with -h --handlebarPath (only valid for amd-style)',
+        'alias': 'runtimeModuleName',
+        'default': 'handlebars.runtime'
       },
 
       'help': {

--- a/lib/precompiler.js
+++ b/lib/precompiler.js
@@ -172,7 +172,7 @@ module.exports.cli = function(opts) {
   let output = new SourceNode();
   if (!opts.simple) {
     if (opts.amd) {
-      output.add('define([\'' + opts.handlebarPath + 'handlebars.runtime\'], function(Handlebars) {\n  Handlebars = Handlebars["default"];');
+      output.add('define([\'' + opts.handlebarPath + opts.runtimeModuleName + '\'], function(Handlebars) {\n  Handlebars = Handlebars["default"];');
     } else if (opts.commonjs) {
       output.add('var Handlebars = require("' + opts.commonjs + '");');
     } else {


### PR DESCRIPTION
See https://github.com/wycats/handlebars.js/issues/1390.

I haven't added tests yet for this change as I could not see any existing ones for `handlebarPath` or `namespace`. Please can you advise if you would like these adding, and where I should do this?

Is there a separate repository for documentation I should update for this new CLI variable?

