### PR TITLE
Revert "Escape = in HTML content"

### DIFF
--- a/lib/handlebars/utils.js
+++ b/lib/handlebars/utils.js
@@ -4,12 +4,13 @@ const escape = {
   '>': '&gt;',
   '"': '&quot;',
   "'": '&#x27;',
-  '`': '&#x60;',
-  '=': '&#x3D;'
+  '`': '&#x60;'
+  // The "equals-sign" is intentionally excluded from this list
+  // due to semantic-versioning issues (see #1489)
 };
 
-const badChars = /[&<>"'`=]/g,
-      possible = /[&<>"'`=]/;
+const badChars = /[&<>"'`]/g,
+      possible = /[&<>"'`]/;
 
 function escapeChar(chr) {
   return escape[chr];

--- a/spec/utils.js
+++ b/spec/utils.js
@@ -18,7 +18,9 @@ describe('utils', function() {
   describe('#escapeExpression', function() {
     it('shouhld escape html', function() {
       equals(Handlebars.Utils.escapeExpression('foo<&"\'>'), 'foo&lt;&amp;&quot;&#x27;&gt;');
-      equals(Handlebars.Utils.escapeExpression('foo='), 'foo&#x3D;');
+    });
+    it('should not escape the equals-sign in 3.x (#1489)', function() {
+      equals(Handlebars.Utils.escapeExpression('foo='), 'foo=');
     });
     it('should not escape SafeString', function() {
       var string = new Handlebars.SafeString('foo<&"\'>');


### PR DESCRIPTION
This reverts commit 1c863e34, a change that was illegal in a patch bump (by semver semantics).

The security fix will be added as an option in a separate commit and released as 3.1.0

see #1489
