### PR TITLE
Use objects for hash value tracking

### DIFF
--- a/lib/handlebars/compiler/javascript-compiler.js
+++ b/lib/handlebars/compiler/javascript-compiler.js
@@ -535,7 +535,7 @@ JavaScriptCompiler.prototype = {
     if (this.hash) {
       this.hashes.push(this.hash);
     }
-    this.hash = {values: [], types: [], contexts: [], ids: []};
+    this.hash = {values: {}};
   },
   popHash: function() {
     let hash = this.hash;

--- a/spec/regressions.js
+++ b/spec/regressions.js
@@ -291,4 +291,14 @@ describe('Regressions', function() {
     };
     shouldCompileToWithPartials(string, [{}, {}, partials], true, 'template  block  partial  block  template');
   });
+  it('should allow hash with protected array names', function() {
+    var obj = {array: [1], name: 'John'};
+    var helpers = {
+      helpa: function(options) {
+        return options.hash.length;
+      }
+    };
+
+    shouldCompileTo('{{helpa length="foo"}}', [obj, helpers], 'foo');
+  });
 });


### PR DESCRIPTION
The use of arrays was incorrect for the data type and causing problems when hash keys conflicted with array behaviors.

Fixes #1194

