### PR TITLE
Use `neo-async` instead of `async

### DIFF
--- a/bench/dist-size.js
+++ b/bench/dist-size.js
@@ -1,4 +1,4 @@
-var async = require('async'),
+var async = require('neo-async'),
     fs = require('fs'),
     zlib = require('zlib');
 

--- a/lib/precompiler.js
+++ b/lib/precompiler.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import Async from 'async';
+import Async from 'neo-async';
 import fs from 'fs';
 import * as Handlebars from './handlebars';
 import {basename} from 'path';

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "node": ">=0.4.7"
   },
   "dependencies": {
-    "async": "^2.5.0",
+    "neo-async": "^2.6.0",
     "optimist": "^0.6.1",
     "source-map": "^0.6.1"
   },

--- a/tasks/metrics.js
+++ b/tasks/metrics.js
@@ -1,5 +1,5 @@
 var _ = require('underscore'),
-    async = require('async'),
+    async = require('neo-async'),
     metrics = require('../bench');
 
 module.exports = function(grunt) {

--- a/tasks/publish.js
+++ b/tasks/publish.js
@@ -1,5 +1,5 @@
 var _ = require('underscore'),
-    async = require('async'),
+    async = require('neo-async'),
     AWS = require('aws-sdk'),
     git = require('./util/git'),
     semver = require('semver');
@@ -66,7 +66,7 @@ module.exports = function(grunt) {
     var s3 = new AWS.S3(),
         bucket = process.env.S3_BUCKET_NAME;
 
-    async.forEach(_.keys(files), function(file, callback) {
+    async.each(_.keys(files), function(file, callback) {
         var params = {Bucket: bucket, Key: file, Body: grunt.file.read(files[file])};
         s3.putObject(params, function(err) {
           if (err) {

--- a/tasks/version.js
+++ b/tasks/version.js
@@ -1,4 +1,4 @@
-var async = require('async'),
+var async = require('neo-async'),
     git = require('./util/git'),
     semver = require('semver');
 


### PR DESCRIPTION
Closes #1431 
Related to #1428 

`neo-async` does not have the heave-weight lodash dependency and is more efficient.