### PR TITLE
test: add test for NodeJS compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ before_install:
 - npm install -g grunt-cli
 script:
 - grunt --stack travis
+- multi-nodejs-test/run-tests.sh 0.10 0.12 4 5 6 7 8 9 10 11
 email:
   on_failure: change
   on_success: never

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,7 +12,8 @@ module.exports = function(grunt) {
         'bench/**/*.js',
         'tasks/**/*.js',
         'lib/**/!(*.min|parser).js',
-        'spec/**/!(*.amd|json2|require).js'
+        'spec/**/!(*.amd|json2|require).js',
+        'multi-nodejs-test/*.js'
       ]
     },
 

--- a/multi-nodejs-test/.eslintrc.js
+++ b/multi-nodejs-test/.eslintrc.js
@@ -1,0 +1,114 @@
+module.exports = {
+  "extends": "eslint:recommended",
+  "globals": {
+    "self": false
+  },
+  "env": {
+    "node": true
+  },
+  "rules": {
+    // overrides eslint:recommended defaults
+    "no-sparse-arrays": "off",
+    "no-func-assign": "off",
+    "no-console": "off",
+    "no-debugger": "warn",
+    "no-unreachable": "warn",
+
+    // Possible Errors //
+    //-----------------//
+    "no-unsafe-negation": "error",
+
+
+    // Best Practices //
+    //----------------//
+    "curly": "error",
+    "default-case": "warn",
+    "dot-notation": ["error", { "allowKeywords": false }],
+    "guard-for-in": "warn",
+    "no-alert": "error",
+    "no-caller": "error",
+    "no-div-regex": "warn",
+    "no-eval": "error",
+    "no-extend-native": "error",
+    "no-extra-bind": "error",
+    "no-floating-decimal": "error",
+    "no-implied-eval": "error",
+    "no-iterator": "error",
+    "no-labels": "error",
+    "no-lone-blocks": "error",
+    "no-loop-func": "error",
+    "no-multi-spaces": "error",
+    "no-multi-str": "warn",
+    "no-global-assign": "error",
+    "no-new": "error",
+    "no-new-func": "error",
+    "no-new-wrappers": "error",
+    "no-octal-escape": "error",
+    "no-process-env": "error",
+    "no-proto": "error",
+    "no-return-assign": "error",
+    "no-script-url": "error",
+    "no-self-compare": "error",
+    "no-sequences": "error",
+    "no-throw-literal": "error",
+    "no-unused-expressions": "error",
+    "no-warning-comments": "warn",
+    "no-with": "error",
+    "radix": "error",
+    "wrap-iife": "error",
+
+
+    // Variables //
+    //-----------//
+    "no-catch-shadow": "error",
+    "no-label-var": "error",
+    "no-shadow-restricted-names": "error",
+    "no-undef-init": "error",
+    "no-use-before-define": ["error", "nofunc"],
+
+
+    // Stylistic Issues //
+    //------------------//
+    "comma-dangle": ["error", "never"],
+    "quote-props": ["error", "as-needed", { "keywords": true, "unnecessary": false }],
+    "brace-style": ["error", "1tbs", { "allowSingleLine": true }],
+    "camelcase": "error",
+    "comma-spacing": ["error", { "before": false, "after": true }],
+    "comma-style": ["error", "last"],
+    "consistent-this": ["warn", "self"],
+    "eol-last": "error",
+    "func-style": ["error", "declaration"],
+    "key-spacing": ["error", {
+      "beforeColon": false,
+      "afterColon": true
+    }],
+    "new-cap": "error",
+    "new-parens": "error",
+    "no-array-constructor": "error",
+    "no-lonely-if": "error",
+    "no-mixed-spaces-and-tabs": "error",
+    "no-nested-ternary": "warn",
+    "no-new-object": "error",
+    "no-spaced-func": "error",
+    "no-trailing-spaces": "error",
+    "no-extra-parens": ["error", "functions"],
+    "quotes": ["error", "single", "avoid-escape"],
+    "semi": "error",
+    "semi-spacing": ["error", { "before": false, "after": true }],
+    "keyword-spacing": "error",
+    "space-before-blocks": ["error", "always"],
+    "space-before-function-paren": ["error", { "anonymous": "never", "named": "never" }],
+    "space-in-parens": ["error", "never"],
+    "space-infix-ops": "error",
+    "space-unary-ops": "error",
+    "spaced-comment": ["error", "always", { "markers": [","] }],
+    "wrap-regex": "warn",
+
+    // ECMAScript 6 //
+    //--------------//
+    "no-var": "off"
+  },
+  "parserOptions": {
+    "sourceType": "module"
+  }
+}

--- a/multi-nodejs-test/expected.txt
+++ b/multi-nodejs-test/expected.txt
@@ -1,0 +1,1 @@
+Author: Yehuda

--- a/multi-nodejs-test/run-handlebars.js
+++ b/multi-nodejs-test/run-handlebars.js
@@ -1,0 +1,13 @@
+// This test should run with node 0.10 as long as Handlebars has been compiled before
+var Handlebars = require('../');
+var fs = require('fs');
+
+console.log('Testing build Handlebars with Node version ' + process.version);
+var template = fs.readFileSync(require.resolve('./template.txt.hbs'), 'utf-8');
+var compiledOutput = Handlebars.compile(template)({author: 'Yehuda'}).trim();
+var expectedOutput = fs.readFileSync(require.resolve('./expected.txt'), 'utf-8').trim();
+
+if (compiledOutput !== expectedOutput) {
+    throw new Error('Compiled output (' + compiledOutput + ') did not match expected output (' + expectedOutput + ')');
+}
+console.log('Success');

--- a/multi-nodejs-test/run-tests.sh
+++ b/multi-nodejs-test/run-tests.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+cd "$( dirname "$( readlink -f "$0" )" )"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+
+# This script tests with precompiler and the built distribution with multiple NodeJS version.
+# The rest of the travis-build will only work with newer NodeJS versions, because the build
+# tools don't support older versions.
+# However, the built distribution should work with older NodeJS versions as well.
+# This test is simple by design. It merely ensures, that calling Handlebars does not fail with old versions.
+# It does (almost) not test for correctness, because that is already done in the mocha-tests.
+# And it does not use any NodeJS based testing framwork to make this part independent of the Node version.
+
+# A list of NodeJS versions is expected as cli-args
+echo "Handlebars should be able to run in various versions of NodeJS"
+for i in "$@" ; do
+    nvm install "$i"
+    nvm exec "$i" node ./run-handlebars.js >/dev/null || exit 1
+    nvm exec "$i" node ../bin/handlebars template.txt.hbs >/dev/null || exit 1
+    echo Success
+done

--- a/multi-nodejs-test/template.txt.hbs
+++ b/multi-nodejs-test/template.txt.hbs
@@ -1,0 +1,1 @@
+Author: {{author}} 


### PR DESCRIPTION
The test is a simple addition to the existing tests. It should ensure
that the built Handlebars artifact only uses language features that are
available in old versions of NodeJS. A simple program and the
precompiler are started with NodeJS 0.10 to 11

Before creating a pull-request, please check https://github.com/wycats/handlebars.js/blob/master/CONTRIBUTING.md first.

Generally we like to see pull requests that

- [x] Please don't start pull requests for security issues. Instead, file a report at https://www.npmjs.com/advisories/report?package=handlebars
- [x] Maintain the existing code style
- [x] Are focused on a single change (i.e. avoid large refactoring or style adjustments in untouched code if not the primary goal of the pull request)
- [x] Have good commit messages
- [x] Have tests
- [x] Have the [typings](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html) (lib/handlebars.d.ts) updated on every API change. If you need help, updating those, please mention that in the PR description.
- [x] Don't significantly decrease the current code coverage (see coverage/lcov-report/index.html)
- [x] Currently, the `4.x`-branch contains the latest version. Please target that branch in the PR. 