### PR TITLE
deprecate substr method and use existing strip function in grammar

### DIFF
--- a/lib/handlebars/compiler/helpers.js
+++ b/lib/handlebars/compiler/helpers.js
@@ -24,7 +24,7 @@ export function SourceLocation(source, locInfo) {
 
 export function id(token) {
   if (/^\[.*\]$/.test(token)) {
-    return token.substr(1, token.length - 2);
+    return token.substring(1, token.length - 1);
   } else {
     return token;
   }

--- a/src/handlebars.l
+++ b/src/handlebars.l
@@ -4,7 +4,7 @@
 %{
 
 function strip(start, end) {
-  return yytext = yytext.substr(start, yyleng-end);
+  return yytext = yytext.substring(start, yyleng - end + start);
 }
 
 %}
@@ -59,7 +59,7 @@ ID    [^\s!"#%-,\.\/;->@\[-\^`\{-~]+/{LOOKAHEAD}
                                   if (this.conditionStack[this.conditionStack.length-1] === 'raw') {
                                     return 'CONTENT';
                                   } else {
-                                    yytext = yytext.substr(5, yyleng-9);
+                                    strip(5, 9);
                                     return 'END_RAW_BLOCK';
                                   }
                                  }


### PR DESCRIPTION
[String.prototype.substr(...)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) method is discouraged and should use `substring` when possible.

Before creating a pull-request, please check https://github.com/wycats/handlebars.js/blob/master/CONTRIBUTING.md first.

Generally we like to see pull requests that

- [ ] Please don't start pull requests for security issues. Instead, file a report at https://www.npmjs.com/advisories/report?package=handlebars
- [ ] Maintain the existing code style
- [ ] Are focused on a single change (i.e. avoid large refactoring or style adjustments in untouched code if not the primary goal of the pull request)
- [ ] Have good commit messages
- [ ] Have tests
- [ ] Have the [typings](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html) (lib/handlebars.d.ts) updated on every API change. If you need help, updating those, please mention that in the PR description.
- [ ] Don't significantly decrease the current code coverage (see coverage/lcov-report/index.html)
- [ ] Currently, the `4.x`-branch contains the latest version. Please target that branch in the PR. 