### PR TITLE
V1.3.x (Retrofit Security Patch...)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -96,7 +96,7 @@ module.exports = function(grunt) {
     uglify: {
       options: {
         mangle: true,
-        compress: true,
+        compress: {},
         preserveComments: 'some'
       },
       dist: {
@@ -169,10 +169,12 @@ module.exports = function(grunt) {
 
   // Build a new version of the library
   this.registerTask('build', "Builds a distributable version of the current project", [
+                    'clean',
+                    'jshint',
                     'parser',
                     'node',
-                    'globals',
-                    'jshint']);
+                    'globals'
+                  ]);
 
   this.registerTask('amd', ['packager:amd', 'requirejs']);
   this.registerTask('node', ['packager:cjs']);

--- a/lib/handlebars/compiler/javascript-compiler.js
+++ b/lib/handlebars/compiler/javascript-compiler.js
@@ -11,6 +11,10 @@ JavaScriptCompiler.prototype = {
   // PUBLIC API: You can override these methods in a subclass to provide
   // alternative compiled forms for name lookup and buffering semantics
   nameLookup: function(parent, name /* , type*/) {
+    if (name === 'constructor') {
+      return ['(', parent, '.propertyIsEnumerable(\'constructor\') ? ', parent, '.constructor : undefined', ')'];
+    }
+
     var wrap,
         ret;
     if (parent.indexOf('depth') === 0) {

--- a/lib/handlebars/utils.js
+++ b/lib/handlebars/utils.js
@@ -7,11 +7,12 @@ var escape = {
   ">": "&gt;",
   '"': "&quot;",
   "'": "&#x27;",
-  "`": "&#x60;"
+  "`": "&#x60;",
+  '=': '&#x3D;'
 };
 
-var badChars = /[&<>"'`]/g;
-var possible = /[&<>"'`]/;
+var badChars = /[&<>"'`=]/g;
+var possible = /[&<>"'`=]/;
 
 function escapeChar(chr) {
   return escape[chr] || "&amp;";

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "handlebars",
   "barename": "handlebars",
-  "version": "1.3.0",
+  "version": "1.3.0-security-patch-1",
   "description": "Handlebars provides the power necessary to let you build semantic templates effectively with no frustration",
   "homepage": "http://www.handlebarsjs.com/",
   "keywords": [


### PR DESCRIPTION
granted - this will probably be closed as soon as it is opened - however... this _would_ help teams that may have a legacy build that still uses this old ass version ;)

Original PR this PR is based on can be found here: https://github.com/wycats/handlebars.js/commit/83b8e846a3569bd366cf0b6bdc1e4604d1a2077e

Idea is simply to have a `1.3.x` branch so that a `1.3.whatever` tag can be generated from it with the patch applied...

if you guys could create a `v1.3.x` branch and update this PR to be merged into it - that would effectively do what we're after here...