### PR TITLE
Fix some small typos.

### DIFF
--- a/lib/handlebars/compiler/whitespace-control.js
+++ b/lib/handlebars/compiler/whitespace-control.js
@@ -206,7 +206,7 @@ function omitLeft(body, i, multiple) {
     return;
   }
 
-  // We omit the last node if it's whitespace only and not preceeded by a non-content node.
+  // We omit the last node if it's whitespace only and not preceded by a non-content node.
   let original = current.value;
   current.value = current.value.replace(multiple ? (/\s+$/) : (/[ \t]+$/), '');
   current.leftStripped = current.value !== original;

--- a/lib/handlebars/runtime.js
+++ b/lib/handlebars/runtime.js
@@ -32,7 +32,7 @@ export function template(templateSpec, env) {
   templateSpec.main.decorator = templateSpec.main_d;
 
   // Note: Using env.VM references rather than local var references throughout this section to allow
-  // for external users to override these as psuedo-supported APIs.
+  // for external users to override these as pseudo-supported APIs.
   env.VM.checkRevision(templateSpec.compiler);
 
   function invokePartialWrapper(partial, context, options) {

--- a/release-notes.md
+++ b/release-notes.md
@@ -355,7 +355,7 @@ Compatibility notes:
 - Lines containing only block statements and whitespace are now removed. This matches the Mustache spec but may cause issues with code that expects whitespace to exist but would not otherwise.
 - Partials that are standalone will now indent their rendered content
 - `AST.ProgramNode`'s signature has changed. 
-- Numerious methods/features removed from psuedo-API classes
+- Numerious methods/features removed from pseudo-API classes
   - `JavaScriptCompiler.register`
   - `JavaScriptCompiler.replaceStack` no longer supports non-inline replace
   - `Compiler.disassemble`
@@ -546,7 +546,7 @@ Compatibility notes:
 ## v1.0.11 / 1.0.0-rc4 - May 13 2013
 
 - [#458](https://github.com/wycats/handlebars.js/issues/458) - Fix `./foo` syntax ([@jpfiset](https://github.com/jpfiset))
-- [#460](https://github.com/wycats/handlebars.js/issues/460) - Allow `:` in unescaped identifers ([@jpfiset](https://github.com/jpfiset))
+- [#460](https://github.com/wycats/handlebars.js/issues/460) - Allow `:` in unescaped identifiers ([@jpfiset](https://github.com/jpfiset))
 - [#471](https://github.com/wycats/handlebars.js/issues/471) - Create release notes (These!)
 - [#456](https://github.com/wycats/handlebars.js/issues/456) - Allow escaping of `\\`
 - [#211](https://github.com/wycats/handlebars.js/issues/211) - Fix exception in `escapeExpression`


### PR DESCRIPTION
(Note: I've only looked over the 4.x branch, due to that it appears that the 4.x branch is where most active development is occurring currently. Typos could be replicated in other branches maybe, but I haven't checked).