### PR TITLE
feat: allow a custom escapeExpression for an env

### DIFF
--- a/lib/handlebars/runtime.js
+++ b/lib/handlebars/runtime.js
@@ -88,7 +88,7 @@ export function template(templateSpec, env) {
       return typeof current === 'function' ? current.call(context) : current;
     },
 
-    escapeExpression: Utils.escapeExpression,
+    escapeExpression: env.escapeExpression || Utils.escapeExpression,
     invokePartial: invokePartialWrapper,
 
     fn: function(i) {

--- a/spec/basic.js
+++ b/spec/basic.js
@@ -122,6 +122,16 @@ describe('basic context', function() {
           'escaping should properly handle amperstands');
   });
 
+  it('escaping with escapeExpressions override', function() {
+    global.handlebarsEnv.escapeExpression = s => s.replace('&', 'AND');
+    shouldCompileTo('{{awesome}}', {awesome: 'x&y'}, 'xANDy', 'text is escaped using the custom escapeExpression function');
+  });
+
+  it('falls back to the default escapeExpressions', function() {
+    global.handlebarsEnv.escapeExpression = null;
+    shouldCompileTo('{{awesome}}', {awesome: 'x&y'}, 'x&amp;y', 'text is escaped using the standard escapeExpression function');
+  });
+
   it("functions returning safestrings shouldn't be escaped", function() {
     var hash = {awesome: function() { return new Handlebars.SafeString('&\'\\<>'); }};
     shouldCompileTo('{{awesome}}', hash, '&\'\\<>',


### PR DESCRIPTION
We use handlebars.js for both XML templating and JSON templating within the same application. As such, we'd like to be able to override the escapeExpressions function on a single Handlebars environment, rather than globally. This is a small PR that allows us to do that, by first attempting to get the environment's version of `escapeExpression` and falling back to the `Utils` version if that is falsey.

Usage (or how we might end up using it):
```JavaScript
const hb = Handlebars.create();
hb.escapeExpression = str => JSON.stringify(str).slice(1, -1);
// ... continue using 'hb' as normal
```

Please let me know if anything is unclear or if you'd like me to make additional changes.


- [x] Please don't start pull requests for security issues. Instead, file a report at https://www.npmjs.com/advisories/report?package=handlebars
- [x] Maintain the existing code style
- [x] Are focused on a single change (i.e. avoid large refactoring or style adjustments in untouched code if not the primary goal of the pull request)
- [x] Have good commit messages
- [x] Have tests
- [x] Have the [typings](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html) (lib/handlebars.d.ts) updated on every API change. If you need help, updating those, please mention that in the PR description.
- [x] Don't significantly decrease the current code coverage (see coverage/lcov-report/index.html)
- [x] Currently, the `4.x`-branch contains the latest version. Please target that branch in the PR. 