### PR TITLE
Add VM TS mapping

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,15 +5,15 @@ module.exports = function(grunt) {
     pkg: grunt.file.readJSON('package.json'),
 
     eslint: {
-      options: {
-      },
       files: [
         '*.js',
         'bench/**/*.js',
         'tasks/**/*.js',
         'lib/**/!(*.min|parser).js',
         'spec/**/!(*.amd|json2|require).js',
-        'integration-testing/**/*.js'
+        'integration-testing/multi-nodejs-test/*.js',
+        'integration-testing/webpack-test/*.js',
+        'integration-testing/webpack-test/src/*.js'
       ]
     },
 

--- a/lib/handlebars/runtime.js
+++ b/lib/handlebars/runtime.js
@@ -209,6 +209,9 @@ export function wrapProgram(container, i, fn, data, declaredBlockParams, blockPa
   return prog;
 }
 
+/**
+ * This is currently part of the official API, therefore implementation details should not be changed.
+ */
 export function resolvePartial(partial, context, options) {
   if (!partial) {
     if (options.name === '@partial-block') {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -8,6 +8,7 @@
  *   - Sergei Dorogin <https://github.com/evil-shrike>
  *   - webbiesdk <https://github.com/webbiesdk>
  *   - Andrew Leedham <https://github.com/AndrewLeedham>
+ *   - Nils Knappmeier <https://github.com/nknapp>
  * For full history prior to their migration to handlebars.js, please see:
  * https://github.com/DefinitelyTyped/DefinitelyTyped/commits/1ce60bdc07f10e0b076778c6c953271c072bc894/types/handlebars/index.d.ts
  */
@@ -21,7 +22,6 @@ declare namespace Handlebars {
   export type Template<T = any> = TemplateDelegate<T>|string;
 
   export interface RuntimeOptions {
-      name?: string;
       partial?: boolean;
       depths?: any[];
       helpers?: { [name: string]: Function };
@@ -150,11 +150,20 @@ declare namespace Handlebars {
       Hash(hash: hbs.AST.Hash): void;
   }
 
+
+  export interface ResolvePartialOptions {
+    name: string;
+    helpers?: { [name: string]: Function };
+    partials?: { [name: string]: HandlebarsTemplateDelegate };
+    decorators?: { [name: string]: Function };
+    data?: any;
+  }
+
   export namespace VM {
     /**
      * @deprecated
      */
-    export function resolvePartial<T = any>(partial: HandlebarsTemplateDelegate<T> | undefined, context: any, options: RuntimeOptions): HandlebarsTemplateDelegate<T>;
+    export function resolvePartial<T = any>(partial: HandlebarsTemplateDelegate<T> | undefined, context: any, options: ResolvePartialOptions): HandlebarsTemplateDelegate<T>;
   }
 }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,6 +7,7 @@
  *   - Raanan Weber <https://github.com/RaananW>
  *   - Sergei Dorogin <https://github.com/evil-shrike>
  *   - webbiesdk <https://github.com/webbiesdk>
+ *   - Andrew Leedham <https://github.com/AndrewLeedham>
  * For full history prior to their migration to handlebars.js, please see:
  * https://github.com/DefinitelyTyped/DefinitelyTyped/commits/1ce60bdc07f10e0b076778c6c953271c072bc894/types/handlebars/index.d.ts
  */
@@ -20,6 +21,7 @@ declare namespace Handlebars {
   export type Template<T = any> = TemplateDelegate<T>|string;
 
   export interface RuntimeOptions {
+      name?: string;
       partial?: boolean;
       depths?: any[];
       helpers?: { [name: string]: Function };
@@ -147,6 +149,13 @@ declare namespace Handlebars {
       NullLiteral(): void;
       Hash(hash: hbs.AST.Hash): void;
   }
+
+  export namespace VM {
+    /**
+     * @deprecated
+     */
+    export function resolvePartial<T = any>(partial: HandlebarsTemplateDelegate<T> | undefined, context: any, options: RuntimeOptions): HandlebarsTemplateDelegate<T>;
+  }
 }
 
 /**
@@ -222,6 +231,8 @@ interface Logger {
 
   log(level: number, obj: string): void;
 }
+
+type CompilerInfo = [number/* revision */, string /* versions */];
 
 declare namespace hbs {
   namespace AST {

--- a/types/test.ts
+++ b/types/test.ts
@@ -92,8 +92,8 @@ const parsedTmplWithoutOptions = Handlebars.parse('<p>Hello, my name is {{name}}
 
 // Custom partial resolution.
 const originalResolvePartial = Handlebars.VM.resolvePartial;
-Handlebars.VM.resolvePartial = <T>(partial: HandlebarsTemplateDelegate<T> | undefined, context: any, options: RuntimeOptions): HandlebarsTemplateDelegate<T> => {
-  const name = options.name;
+Handlebars.VM.resolvePartial = <T>(partial: HandlebarsTemplateDelegate<T> | undefined, context: any, options: Handlebars.ResolvePartialOptions): HandlebarsTemplateDelegate<T> => {
+  const name = options.name.replace(/my/,'your');
   // transform name.
   options.name = name;
   return originalResolvePartial(partial, context, options);

--- a/types/test.ts
+++ b/types/test.ts
@@ -90,6 +90,16 @@ const parsedTmpl = Handlebars.parse('<p>Hello, my name is {{name}}.</p>', {
 
 const parsedTmplWithoutOptions = Handlebars.parse('<p>Hello, my name is {{name}}.</p>');
 
+// Custom partial resolution.
+const originalResolvePartial = Handlebars.VM.resolvePartial;
+Handlebars.VM.resolvePartial = <T>(partial: HandlebarsTemplateDelegate<T> | undefined, context: any, options: RuntimeOptions): HandlebarsTemplateDelegate<T> => {
+  const name = options.name;
+  // transform name.
+  options.name = name;
+  return originalResolvePartial(partial, context, options);
+}
+
+
 // #1544, allow custom helpers in knownHelpers
 Handlebars.compile('test', {
   knownHelpers: {


### PR DESCRIPTION
I am aware VM is not part of the public API. But, In one of our projects we are overridding the `resolvePartials` function in order to do some custom resolution, it would therefore be useful if it was mapped to TS to aid in that.

Not sure if these typings are 100% accurate, I'm not particularly familiar with the structure of handlebars.js behind the scenes, but I took my best stab at it.

- [x] Please don't start pull requests for security issues. Instead, file a report at https://www.npmjs.com/advisories/report?package=handlebars
- [x] Maintain the existing code style
- [x] Are focused on a single change (i.e. avoid large refactoring or style adjustments in untouched code if not the primary goal of the pull request)
- [x] Have good commit messages
- [x] Have tests
- [x] Have the [typings](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html) (lib/handlebars.d.ts) updated on every API change. If you need help, updating those, please mention that in the PR description.
- [x] Don't significantly decrease the current code coverage (see coverage/lcov-report/index.html)
- [x] Currently, the `4.x`-branch contains the latest version. Please target that branch in the PR. 