### PR TITLE
wip: disallow lambdas and functions in input data...

### DIFF
--- a/components/bower.json
+++ b/components/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "handlebars",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "main": "handlebars.js",
   "license": "MIT",
   "dependencies": {}

--- a/components/handlebars.js.nuspec
+++ b/components/handlebars.js.nuspec
@@ -2,7 +2,7 @@
 <package>
 	<metadata>
 		<id>handlebars.js</id>
-		<version>4.2.0</version>
+		<version>4.2.1</version>
 		<authors>handlebars.js Authors</authors>
 		<licenseUrl>https://github.com/wycats/handlebars.js/blob/master/LICENSE</licenseUrl>
 		<projectUrl>https://github.com/wycats/handlebars.js/</projectUrl>

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "handlebars",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "license": "MIT",
   "jspm": {
     "main": "handlebars",

--- a/integration-testing/webpack-babel-test/.babelrc
+++ b/integration-testing/webpack-babel-test/.babelrc
@@ -1,0 +1,11 @@
+{
+  "plugins": [
+    "@roundingwellos/babel-plugin-handlebars-inline-precompile"
+   // "istanbul"
+  ],
+  "presets": [
+    [
+      "@babel/preset-env"
+    ]
+  ]
+}

--- a/integration-testing/webpack-babel-test/.gitignore
+++ b/integration-testing/webpack-babel-test/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+package-lock.json

--- a/integration-testing/webpack-babel-test/package.json
+++ b/integration-testing/webpack-babel-test/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "webpack-babel-test",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@babel/core": "^7.5.5",
+    "@babel/preset-env": "^7.5.5",
+    "@roundingwellos/babel-plugin-handlebars-inline-precompile": "^3.0.1",
+    "babel-loader": "^8.0.6",
+    "babel-plugin-istanbul": "^5.2.0",
+    "handlebars": "file:../..",
+    "handlebars-loader": "^1.7.1",
+    "nyc": "^14.1.1",
+    "webpack": "^4.39.3",
+    "webpack-cli": "^3.3.7"
+  },
+  "scripts": {
+    "build": "webpack --config webpack.config.js"
+  }
+}

--- a/integration-testing/webpack-babel-test/src/handlebars-inline-precompile-test.js
+++ b/integration-testing/webpack-babel-test/src/handlebars-inline-precompile-test.js
@@ -1,0 +1,12 @@
+import * as Handlebars from 'handlebars/runtime'
+import hbs from 'handlebars-inline-precompile';
+import {assertEquals} from "../../webpack-test/src/lib/assert";
+
+Handlebars.registerHelper('loud', function(text) {
+    return text.toUpperCase();
+});
+
+const template = hbs`{{loud name}}`;
+const output = template({name: 'yehuda'})
+
+assertEquals(output, 'YEHUDA')

--- a/integration-testing/webpack-babel-test/src/lib/assert.js
+++ b/integration-testing/webpack-babel-test/src/lib/assert.js
@@ -1,0 +1,5 @@
+export function assertEquals(actual, expected) {
+    if (actual !== expected) {
+        throw new Error(`Expected "${actual}" to equal "${expected}"`);
+    }
+}

--- a/integration-testing/webpack-babel-test/test.sh
+++ b/integration-testing/webpack-babel-test/test.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+# Cleanup: package-lock and "npm ci" is not working with local dependencies
+rm dist package-lock.json -rf
+npm install
+npm run build
+
+for i in dist/*-test.js ; do
+  echo "----------------------"
+  echo "-- Running $i"
+  echo "----------------------"
+  node "$i"
+  echo "Success"
+done

--- a/integration-testing/webpack-babel-test/webpack.config.js
+++ b/integration-testing/webpack-babel-test/webpack.config.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+
+const testFiles = fs.readdirSync('src');
+const entryPoints = {};
+testFiles
+    .filter(file => file.match(/-test.js$/))
+    .forEach(file => {
+        entryPoints[file] = `./src/${file}`;
+    });
+
+module.exports = {
+    entry: entryPoints,
+    output: {
+        filename: '[name]',
+        path: __dirname + '/dist'
+    },
+    module: {
+        rules: [
+            {
+                test: /\.js?$/,
+                exclude: /node_modules/,
+                use: {
+                    loader: 'babel-loader',
+                    options: { cacheDirectory: false },
+                }
+            }
+        ]
+    },
+    optimization: {
+        minimize: false
+    }
+};

--- a/integration-testing/webpack-test/src/handlebars-require-vs-import-test.js
+++ b/integration-testing/webpack-test/src/handlebars-require-vs-import-test.js
@@ -1,0 +1,10 @@
+import * as HandlebarsViaImport from 'handlebars';
+const HandlebarsViaRequire = require('handlebars');
+import {assertEquals} from './lib/assert';
+
+HandlebarsViaImport.registerHelper('loud', function(text) {
+    return text.toUpperCase();
+});
+
+const template = HandlebarsViaRequire.compile('Author: {{loud author}}');
+assertEquals(template({author: 'Yehuda'}), 'Author: YEHUDA');

--- a/lib/handlebars/base.js
+++ b/lib/handlebars/base.js
@@ -4,7 +4,7 @@ import {registerDefaultHelpers} from './helpers';
 import {registerDefaultDecorators} from './decorators';
 import logger from './logger';
 
-export const VERSION = '4.2.0';
+export const VERSION = '4.2.1';
 export const COMPILER_REVISION = 7;
 
 export const REVISION_CHANGES = {

--- a/lib/handlebars/compiler/javascript-compiler.js
+++ b/lib/handlebars/compiler/javascript-compiler.js
@@ -622,18 +622,34 @@ JavaScriptCompiler.prototype = {
   // If the helper is not found, `helperMissing` is called.
   invokeHelper: function(paramSize, name, isSimple) {
     let nonHelper = this.popStack(),
-        helper = this.setupHelper(paramSize, name),
-        simple = isSimple ? [helper.name, ' || '] : '';
+        helper = this.setupHelper(paramSize, name);
 
-    let lookup = ['('].concat(simple, nonHelper);
-    if (!this.options.strict) {
-      lookup.push(' || ', this.aliasable('helpers.helperMissing'));
+    let possibleFunctionCalls = [];
+
+    if (isSimple) { // direct call to helper
+      possibleFunctionCalls.push(helper.name);
     }
-    lookup.push(')');
+    if (this.options.allowUnsafeFunctionCalls) {
+      // call a function from the input object
+      possibleFunctionCalls.push(nonHelper);
+    }
+    if (!this.options.strict) {
+      possibleFunctionCalls.push(this.aliasable('helpers.helperMissing'));
+    }
 
-    this.push(this.source.functionCall(lookup, 'call', helper.callParams));
+    let functionLookupCode = ['(', this.itemsSeparatedBy(possibleFunctionCalls, '||'), ')'];
+    let functionCall = this.source.functionCall(functionLookupCode, 'call', helper.callParams);
+    this.push(functionCall);
   },
 
+  itemsSeparatedBy: function(items, separator) {
+    let result = [];
+    result.push(items[0]);
+    for (let i = 1; i < items.length; i++) {
+      result.push(separator, items[i]);
+    }
+    return result;
+  },
   // [invokeKnownHelper]
   //
   // On stack, before: hash, inverse, program, params..., ...

--- a/lib/handlebars/compiler/whitespace-control.js
+++ b/lib/handlebars/compiler/whitespace-control.js
@@ -206,7 +206,7 @@ function omitLeft(body, i, multiple) {
     return;
   }
 
-  // We omit the last node if it's whitespace only and not preceeded by a non-content node.
+  // We omit the last node if it's whitespace only and not preceded by a non-content node.
   let original = current.value;
   current.value = current.value.replace(multiple ? (/\s+$/) : (/[ \t]+$/), '');
   current.leftStripped = current.value !== original;

--- a/lib/handlebars/runtime.js
+++ b/lib/handlebars/runtime.js
@@ -32,7 +32,7 @@ export function template(templateSpec, env) {
   templateSpec.main.decorator = templateSpec.main_d;
 
   // Note: Using env.VM references rather than local var references throughout this section to allow
-  // for external users to override these as psuedo-supported APIs.
+  // for external users to override these as pseudo-supported APIs.
   env.VM.checkRevision(templateSpec.compiler);
 
   function invokePartialWrapper(partial, context, options) {

--- a/package.json
+++ b/package.json
@@ -64,8 +64,8 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "browser": {
-    ".": "./dist/handlebars.min.js",
-    "./runtime": "./dist/handlebars.runtime.min.js"
+    ".": "./dist/cjs/handlebars.js",
+    "./runtime": "./dist/cjs/handlebars.runtime.js"
   },
   "bin": {
     "handlebars": "bin/handlebars"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "handlebars",
   "barename": "handlebars",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "Handlebars provides the power necessary to let you build semantic templates effectively with no frustration",
   "homepage": "http://www.handlebarsjs.com/",
   "keywords": [

--- a/release-notes.md
+++ b/release-notes.md
@@ -2,7 +2,17 @@
 
 ## Development
 
-[Commits](https://github.com/wycats/handlebars.js/compare/v4.2.0...master)
+[Commits](https://github.com/wycats/handlebars.js/compare/v4.2.1...master)
+
+## v4.2.1 - September 20th, 2019
+Bugfixes: 
+
+- The "browser" property in the package.json has been updated to use the common-js builds instead of the minified UMD - c55a7be, #1553
+
+Compatibility notes:
+- No compatibility issues should arise
+
+[Commits](https://github.com/wycats/handlebars.js/compare/v4.2.0...v4.2.1)
 
 ## v4.2.0 - September 3rd, 2019
 Chore/Test:

--- a/release-notes.md
+++ b/release-notes.md
@@ -406,7 +406,7 @@ Compatibility notes:
 - Lines containing only block statements and whitespace are now removed. This matches the Mustache spec but may cause issues with code that expects whitespace to exist but would not otherwise.
 - Partials that are standalone will now indent their rendered content
 - `AST.ProgramNode`'s signature has changed. 
-- Numerious methods/features removed from psuedo-API classes
+- Numerious methods/features removed from pseudo-API classes
   - `JavaScriptCompiler.register`
   - `JavaScriptCompiler.replaceStack` no longer supports non-inline replace
   - `Compiler.disassemble`
@@ -597,7 +597,7 @@ Compatibility notes:
 ## v1.0.11 / 1.0.0-rc4 - May 13 2013
 
 - [#458](https://github.com/wycats/handlebars.js/issues/458) - Fix `./foo` syntax ([@jpfiset](https://github.com/jpfiset))
-- [#460](https://github.com/wycats/handlebars.js/issues/460) - Allow `:` in unescaped identifers ([@jpfiset](https://github.com/jpfiset))
+- [#460](https://github.com/wycats/handlebars.js/issues/460) - Allow `:` in unescaped identifiers ([@jpfiset](https://github.com/jpfiset))
 - [#471](https://github.com/wycats/handlebars.js/issues/471) - Create release notes (These!)
 - [#456](https://github.com/wycats/handlebars.js/issues/456) - Allow escaping of `\\`
 - [#211](https://github.com/wycats/handlebars.js/issues/211) - Fix exception in `escapeExpression`


### PR DESCRIPTION
...unless explicitly setting "allowUnsafeFunctionCalls"
in the compile options

* It is *NOT* backwards-compatible.
* The old, unsafe, behavior can be configured by setting "allowUnsafeFunctionCalls" to "true" in the compiler options.

@ErisDS @wycats I would like your oppinion on this. If you agree, I will add (and fix) tests and docs. Then I'll release this.

Despite the breaking change, I would only bump the patch version, as @ErisDS suggested lately. 
