### PR TITLE
fix: use cjs for browser fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,8 +64,8 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "browser": {
-    ".": "./dist/handlebars.min.js",
-    "./runtime": "./dist/handlebars.runtime.min.js"
+    ".": "./dist/cjs/handlebars.js",
+    "./runtime": "./dist/cjs/handlebars.runtime.js"
   },
   "bin": {
     "handlebars": "bin/handlebars"


### PR DESCRIPTION
We should not be using pre-built files for the `browser`.  Resolves https://github.com/wycats/handlebars.js/issues/1553
