### PR TITLE
Added support for iterable objects in {{#each}} helper

### DIFF
--- a/lib/handlebars/helpers/each.js
+++ b/lib/handlebars/helpers/each.js
@@ -50,7 +50,12 @@ export default function(instance) {
           }
         }
       } else if (global.Symbol && context[global.Symbol.iterator]) {
-        context = [...context];
+        const newContext = [];
+        const iterator = context[global.Symbol.iterator]();
+        for (let it = iterator.next(); !it.done; it = iterator.next()) {
+          newContext.push(it.value);
+        }
+        context = newContext;
         for (let j = context.length; i < j; i++) {
           execIteration(i, i, i === context.length - 1);
         }

--- a/lib/handlebars/helpers/each.js
+++ b/lib/handlebars/helpers/each.js
@@ -49,6 +49,11 @@ export default function(instance) {
             execIteration(i, i, i === context.length - 1);
           }
         }
+      } else if (global.Symbol && context[global.Symbol.iterator]) {
+        context = [...context];
+        for (let j = context.length; i < j; i++) {
+          execIteration(i, i, i === context.length - 1);
+        }
       } else {
         let priorKey;
 

--- a/spec/builtins.js
+++ b/spec/builtins.js
@@ -265,10 +265,13 @@ describe('builtin helpers', function() {
             yield {text: 'GOODBYE'};
           }
         };
+        var goodbyesEmpty = {
+          * [global.Symbol.iterator]() {}
+        };
         var hash = {goodbyes: goodbyes, world: 'world'};
         shouldCompileTo(string, hash, 'goodbye! Goodbye! GOODBYE! cruel world!',
           'each with array argument iterates over the contents when not empty');
-        shouldCompileTo(string, {goodbyes: [], world: 'world'}, 'cruel world!',
+        shouldCompileTo(string, {goodbyes: goodbyesEmpty, world: 'world'}, 'cruel world!',
           'each with array argument ignores the contents when empty');
       });
     }

--- a/spec/builtins.js
+++ b/spec/builtins.js
@@ -255,19 +255,29 @@ describe('builtin helpers', function() {
       }, handlebarsEnv.Exception, 'Must pass iterator to #each');
     });
 
-    if (global.Symbol) {
+    if (global.Symbol && global.Symbol.iterator) {
       it('each on iterable', function() {
-        var string = '{{#each goodbyes}}{{text}}! {{/each}}cruel {{world}}!';
-        var goodbyes = {
-          * [global.Symbol.iterator]() {
-            yield {text: 'goodbye'};
-            yield {text: 'Goodbye'};
-            yield {text: 'GOODBYE'};
+        function Iterator(arr) {
+          this.arr = arr;
+          this.index = 0;
+        }
+        Iterator.prototype.next = function() {
+          var value = this.arr[this.index];
+          var done = this.index === this.arr.length;
+          if (!done) {
+            this.index++;
           }
+          return { value: value, done: done };
         };
-        var goodbyesEmpty = {
-          * [global.Symbol.iterator]() {}
+        function Iterable(arr) {
+          this.arr = arr;
+        }
+        Iterable.prototype[global.Symbol.iterator] = function() {
+          return new Iterator(this.arr);
         };
+        var string = '{{#each goodbyes}}{{text}}! {{/each}}cruel {{world}}!';
+        var goodbyes = new Iterable([{text: 'goodbye'}, {text: 'Goodbye'}, {text: 'GOODBYE'}]);
+        var goodbyesEmpty = new Iterable([]);
         var hash = {goodbyes: goodbyes, world: 'world'};
         shouldCompileTo(string, hash, 'goodbye! Goodbye! GOODBYE! cruel world!',
           'each with array argument iterates over the contents when not empty');

--- a/spec/builtins.js
+++ b/spec/builtins.js
@@ -254,6 +254,24 @@ describe('builtin helpers', function() {
         template({});
       }, handlebarsEnv.Exception, 'Must pass iterator to #each');
     });
+
+    if (global.Symbol) {
+      it('each on iterable', function() {
+        var string = '{{#each goodbyes}}{{text}}! {{/each}}cruel {{world}}!';
+        var goodbyes = {
+          * [global.Symbol.iterator]() {
+            yield {text: 'goodbye'};
+            yield {text: 'Goodbye'};
+            yield {text: 'GOODBYE'};
+          }
+        };
+        var hash = {goodbyes: goodbyes, world: 'world'};
+        shouldCompileTo(string, hash, 'goodbye! Goodbye! GOODBYE! cruel world!',
+          'each with array argument iterates over the contents when not empty');
+        shouldCompileTo(string, {goodbyes: [], world: 'world'}, 'cruel world!',
+          'each with array argument ignores the contents when empty');
+      });
+    }
   });
 
   describe('#log', function() {


### PR DESCRIPTION
Currently {{#each}} helper supports either arrays, or objects,
however nowadays you can define custom iterable objects by overriding
a special method called Symbol.iterator, which results in empty result
being rendered.

- [x] Please don't start pull requests for security issues. Instead, file a report at https://www.npmjs.com/advisories/report?package=handlebars
- [x] Maintain the existing code style
- [x] Are focused on a single change (i.e. avoid large refactoring or style adjustments in untouched code if not the primary goal of the pull request)
- [x] Have good commit messages
- [x] Have tests
- [x] Have the [typings](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html) (lib/handlebars.d.ts) updated on every API change. If you need help, updating those, please mention that in the PR description.
- [x] Don't significantly decrease the current code coverage (see coverage/lcov-report/index.html)
- [x] Currently, the `4.x`-branch contains the latest version. Please target that branch in the PR. 