### PR TITLE
Added missing type fields for some interfaces

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -270,6 +270,7 @@ declare namespace hbs {
       interface Statement extends Node {}
 
       interface MustacheStatement extends Statement {
+          type: 'MustacheStatement';
           path: PathExpression | Literal;
           params: Expression[];
           hash: Hash;
@@ -280,6 +281,7 @@ declare namespace hbs {
       interface Decorator extends MustacheStatement { }
 
       interface BlockStatement extends Statement {
+          type: 'BlockStatement';
           path: PathExpression;
           params: Expression[];
           hash: Hash;
@@ -293,6 +295,7 @@ declare namespace hbs {
       interface DecoratorBlock extends BlockStatement { }
 
       interface PartialStatement extends Statement {
+          type: 'PartialStatement';
           name: PathExpression | SubExpression;
           params: Expression[];
           hash: Hash;
@@ -301,6 +304,7 @@ declare namespace hbs {
       }
 
       interface PartialBlockStatement extends Statement {
+          type: 'PartialBlockStatement';
           name: PathExpression | SubExpression;
           params: Expression[];
           hash: Hash;
@@ -310,11 +314,13 @@ declare namespace hbs {
       }
 
       interface ContentStatement extends Statement {
+          type: 'ContentStatement';
           value: string;
           original: StripFlags;
       }
 
       interface CommentStatement extends Statement {
+          type: 'CommentStatement';
           value: string;
           strip: StripFlags;
       }
@@ -328,6 +334,7 @@ declare namespace hbs {
       }
 
       interface PathExpression extends Expression {
+          type: 'PathExpression';
           data: boolean;
           depth: number;
           parts: string[];
@@ -336,16 +343,19 @@ declare namespace hbs {
 
       interface Literal extends Expression {}
       interface StringLiteral extends Literal {
+          type: 'StringLiteral';
           value: string;
           original: string;
       }
 
       interface BooleanLiteral extends Literal {
+          type: 'BooleanLiteral';
           value: boolean;
           original: boolean;
       }
 
       interface NumberLiteral extends Literal {
+          type: 'NumberLiteral';
           value: number;
           original: number;
       }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -328,6 +328,7 @@ declare namespace hbs {
       interface Expression extends Node {}
 
       interface SubExpression extends Expression {
+          type: 'SubExpression';
           path: PathExpression;
           params: Expression[];
           hash: Hash;
@@ -360,15 +361,21 @@ declare namespace hbs {
           original: number;
       }
 
-      interface UndefinedLiteral extends Literal {}
+      interface UndefinedLiteral extends Literal {
+          type: 'UndefinedLiteral';
+	  }
 
-      interface NullLiteral extends Literal {}
+      interface NullLiteral extends Literal {
+          type: 'NullLiteral';
+	  }
 
       interface Hash extends Node {
+          type: 'Hash';
           pairs: HashPair[];
       }
 
       interface HashPair extends Node {
+          type: 'HashPair';
           key: string;
           value: Expression;
       }

--- a/types/test.ts
+++ b/types/test.ts
@@ -109,3 +109,84 @@ Handlebars.compile('test', {
 });
 
 Handlebars.compile('test')({},{allowCallsToHelperMissing: true});
+
+const allthings = {} as hbs.AST.MustacheStatement |
+	hbs.AST.BlockStatement |
+	hbs.AST.PartialStatement |
+	hbs.AST.PartialBlockStatement |
+	hbs.AST.ContentStatement |
+	hbs.AST.CommentStatement |
+	hbs.AST.SubExpression |
+	hbs.AST.PathExpression |
+	hbs.AST.StringLiteral |
+	hbs.AST.BooleanLiteral |
+	hbs.AST.NumberLiteral |
+	hbs.AST.UndefinedLiteral |
+	hbs.AST.NullLiteral |
+	hbs.AST.Hash |
+	hbs.AST.HashPair;
+
+switch(allthings.type) {
+	case "MustacheStatement":
+		let mustacheStatement: hbs.AST.MustacheStatement;
+		mustacheStatement = allthings;
+		break;
+	case "BlockStatement":
+		let blockStatement: hbs.AST.BlockStatement;
+		blockStatement = allthings;
+		break;
+	case "PartialStatement":
+		let partialStatement: hbs.AST.PartialStatement;
+		partialStatement = allthings;
+		break;
+	case "PartialBlockStatement":
+		let partialBlockStatement: hbs.AST.PartialBlockStatement;
+		partialBlockStatement = allthings;
+		break;
+	case "ContentStatement":
+		let ContentStatement: hbs.AST.ContentStatement;
+		ContentStatement = allthings;
+		break;
+	case "CommentStatement":
+		let CommentStatement: hbs.AST.CommentStatement;
+		CommentStatement = allthings;
+		break;
+	case "SubExpression":
+		let SubExpression: hbs.AST.SubExpression;
+		SubExpression = allthings;
+		break;
+	case "PathExpression":
+		let PathExpression: hbs.AST.PathExpression;
+		PathExpression = allthings;
+		break;
+	case "StringLiteral":
+		let StringLiteral: hbs.AST.StringLiteral;
+		StringLiteral = allthings;
+		break;
+	case "BooleanLiteral":
+		let BooleanLiteral: hbs.AST.BooleanLiteral;
+		BooleanLiteral = allthings;
+		break;
+	case "NumberLiteral":
+		let NumberLiteral: hbs.AST.NumberLiteral;
+		NumberLiteral = allthings;
+		break;
+	case "UndefinedLiteral":
+		let UndefinedLiteral: hbs.AST.UndefinedLiteral;
+		UndefinedLiteral = allthings;
+		break;
+	case "NullLiteral":
+		let NullLiteral: hbs.AST.NullLiteral;
+		NullLiteral = allthings;
+		break;
+	case "Hash":
+		let Hash: hbs.AST.Hash;
+		Hash = allthings;
+		break;
+	case "HashPair":
+		let HashPair: hbs.AST.HashPair;
+		HashPair = allthings;
+		break;
+	default:
+		break;
+}


### PR DESCRIPTION
While using the compiler API I ran into some issues with the typings. I wanted to use [discriminated unions](https://www.typescriptlang.org/docs/handbook/advanced-types.html#discriminated-unions) but wasn't able to do so, because the typings are missing discriminant fields. I added those for some interfaces, but didn't want to mess with some others. It might be a good idea to add those, but I'd like to have some feedback first.

It might also be a good idea to rename the interface ```Statement``` to ```StatementBase``` and then add a type called ```Statement``` which is the union of all the Statement interfaces. I don't think that change would break anything. Short example:

```typescript
interface StatementBase implements Node {}

type Statement = ContentStatement | BlockStatement | MustacheStatement | ...;

interface ContentStatement implements StatementBase {
    type: 'ContentStatement';
    value: string;
    original: StripFlags;
}

interface BlockStatement implements StatementBase {
    ...
}

...
```
That would allow for code like this:

```javascript

const program = handlebars.parse(mytemplate);

for(const statement of program) {
    switch(statement.type) {
        case 'ContentStatement':
            console.log(statement.value); // no typescript error
            break;
        ...
        default:
            break;
    }
}

```
Currently - even with this change - this is a bit more cumbersome.


Since this is my first pull request I'd love to get some feedback :)