### PR TITLE
fix: prevent zero length tokens in raw-blocks

### DIFF
--- a/spec/helpers.js
+++ b/spec/helpers.js
@@ -28,14 +28,35 @@ describe('helpers', function() {
                     'raw block helper gets raw content');
   });
 
-  it('helper for nested raw block gets raw content', function() {
-    var string = '{{{{a}}}} {{{{b}}}} {{{{/b}}}} {{{{/a}}}}';
-    var helpers = {
-        a: function(options) {
+  describe('raw block parsing (with identity helper-function)', function() {
+
+    function runWithIdentityHelper(template, expected) {
+      var helpers = {
+        identity: function(options) {
           return options.fn();
-      }
-    };
-    shouldCompileTo(string, [{}, helpers], ' {{{{b}}}} {{{{/b}}}} ', 'raw block helper should get nested raw block as raw content');
+        }
+      };
+      shouldCompileTo(template, [{}, helpers], expected);
+    }
+
+    it('helper for nested raw block gets raw content', function() {
+      runWithIdentityHelper('{{{{identity}}}} {{{{b}}}} {{{{/b}}}} {{{{/identity}}}}', ' {{{{b}}}} {{{{/b}}}} ');
+    });
+
+    it('helper for nested raw block works with empty content', function() {
+      runWithIdentityHelper('{{{{identity}}}}{{{{/identity}}}}', '');
+    });
+
+    it('helper for nested raw block works if nested raw blocks are broken', function() {
+      runWithIdentityHelper('{{{{identity}}}} {{{{a}}}} {{{{ {{{{/ }}}} }}}} {{{{/identity}}}}', ' {{{{a}}}} {{{{ {{{{/ }}}} }}}} ');
+    });
+
+    it('helper for nested raw block throw exception when with missing closing braces', function() {
+      var string = '{{{{a}}}} {{{{/a';
+      shouldThrow(() => {
+        Handlebars.compile(string)();
+      });
+    });
   });
 
   it('helper block with identical context', function() {

--- a/spec/helpers.js
+++ b/spec/helpers.js
@@ -53,7 +53,7 @@ describe('helpers', function() {
 
     it('helper for nested raw block throw exception when with missing closing braces', function() {
       var string = '{{{{a}}}} {{{{/a';
-      shouldThrow(() => {
+      shouldThrow(function() {
         Handlebars.compile(string)();
       });
     });

--- a/src/handlebars.l
+++ b/src/handlebars.l
@@ -63,7 +63,7 @@ ID    [^\s!"#%-,\.\/;->@\[-\^`\{-~]+/{LOOKAHEAD}
                                     return 'END_RAW_BLOCK';
                                   }
                                  }
-<raw>[^\x00]*?/("{{{{")          { return 'CONTENT'; }
+<raw>[^\x00]+/("{{{{")          { return 'CONTENT'; }
 
 <com>[\s\S]*?"--"{RIGHT_STRIP}?"}}" {
   this.popState();

--- a/src/handlebars.yy
+++ b/src/handlebars.yy
@@ -39,7 +39,7 @@ content
   };
 
 rawBlock
-  : openRawBlock content+ END_RAW_BLOCK -> yy.prepareRawBlock($1, $2, $3, @$)
+  : openRawBlock content* END_RAW_BLOCK -> yy.prepareRawBlock($1, $2, $3, @$)
   ;
 
 openRawBlock


### PR DESCRIPTION
The parser has problems when a zero-length `CONTENT` token is detected within a `raw-block`. 