### PR TITLE
Add missing types for the Exception class properties

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -86,15 +86,8 @@ declare namespace Handlebars {
 
   export function noConflict(): typeof Handlebars;
 
-  export interface ExceptionNode {
-      loc?: {
-        start: { line: any; column: any; };
-        end: { line: any; column: any; };
-      }
-  }
-
   export class Exception {
-      constructor(message: string, node?: ExceptionNode);
+      constructor(message: string, node?: hbs.AST.Node);
       description: string;
       fileName: string;
       lineNumber?: any;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -97,8 +97,8 @@ declare namespace Handlebars {
       constructor(message: string, node?: ExceptionNode);
       description: string;
       fileName: string;
-      lineNumber?: string;
-      endLineNumber?: string;
+      lineNumber?: any;
+      endLineNumber?: any;
       message: string;
       name: string;
       number: number;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -86,8 +86,15 @@ declare namespace Handlebars {
 
   export function noConflict(): typeof Handlebars;
 
+  export interface ExceptionNode {
+      loc?: {
+        start: { line: any; column: any; };
+        end: { line: any; column: any; };
+      }
+  }
+
   export class Exception {
-      constructor(message: string);
+      constructor(message: string, node?: ExceptionNode);
       description: string;
       fileName: string;
       lineNumber?: string;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -66,7 +66,6 @@ declare namespace Handlebars {
   export function K(): void;
   export function createFrame(object: any): any;
   export function blockParams(obj: any[], ids: any[]): any[];
-  export function Exception(message: string): void;
   export function log(level: number, obj: any): void;
   export function parse(input: string, options?: ParseOptions): hbs.AST.Program;
   export function parseWithoutProcessing(input: string, options?: ParseOptions): hbs.AST.Program;
@@ -86,6 +85,20 @@ declare namespace Handlebars {
   export const decorators: { [name: string]: Function };
 
   export function noConflict(): typeof Handlebars;
+
+  export class Exception {
+      constructor(message: string);
+      description: string;
+      fileName: string;
+      lineNumber?: string;
+      endLineNumber?: string;
+      message: string;
+      name: string;
+      number: number;
+      stack?: string;
+      column?: any;
+      endColumn?: any;
+  }
 
   export class SafeString {
       constructor(str: string);

--- a/types/test.ts
+++ b/types/test.ts
@@ -203,42 +203,40 @@ function testParseWithoutProcessing() {
 }
 
 function testExceptionTypings() {
-  // Test exception constructor with just message.
-  try {
-    const exp = new Handlebars.Exception('Just a test message.');
-  
-    // Assert
-    exp.message === 'Just a test message.' ? 'Passed': 'Failed';
-  
-    throw exp;
-  } catch(e) {
-    // Catch exception here.
-  }
-  
-  // Test exception constructor with message and node.
-  try {
-    const node: Handlebars.ExceptionNode = {
-      loc: {
-        start: { line: 1, column: 5 },
-        end: { line: 10, column: 2 }
-      }
-    };
-  
-    const exp = new Handlebars.Exception('Just a test message.', node);
-  
-    // Assert
-    exp.message === 'Just a test message.' ? 'Passed': 'Failed';
-    exp.lineNumber === 1 ? 'Passed': 'Failed';
-    exp.column === 5 ? 'Passed': 'Failed';
-    exp.endLineNumber === 10 ? 'Passed': 'Failed';
-    exp.endColumn === 2 ? 'Passed': 'Failed';
-    exp.description; // Could be a string value.
-    exp.name; // Could be a string value. 
-    exp.fileName; // Could be a string value. 
-    exp.stack; // Could be a string value if not undefined.
-    
-    throw exp;
-  } catch(e) {
-    // Catch exception here.
-  }
+  // Test exception constructor with a single argument - message.
+  let exception: Handlebars.Exception = new Handlebars.Exception('message');
+
+  // Fields
+  let message: string = exception.message;
+  let lineNumber: number = exception.lineNumber;
+  let column: number = exception.column;
+  let endLineNumber: number = exception.endLineNumber;
+  let endColumn: number = exception.endColumn;
+  let description = exception.description;
+  let name: string = exception.name;
+  let fileName: string = exception.fileName;
+  let stack: string | undefined = exception.stack;
+}
+
+function testExceptionWithNodeTypings() {
+  // Test exception constructor with both arguments.
+  const exception = new Handlebars.Exception('Just a test message.', {
+    type: 'MustacheStatement',
+    loc: {
+      source: 'source',
+      start: { line: 1, column: 5 },
+      end: { line: 10, column: 2 }
+    }
+  });
+
+  // Fields
+  let message: string = exception.message;
+  let lineNumber: number = exception.lineNumber;
+  let column: number = exception.column;
+  let endLineNumber: number = exception.endLineNumber;
+  let endColumn: number = exception.endColumn;
+  let description = exception.description;
+  let name: string = exception.name;
+  let fileName: string = exception.fileName;
+  let stack: string | undefined = exception.stack;
 }

--- a/types/test.ts
+++ b/types/test.ts
@@ -217,8 +217,8 @@ try {
 try {
   const node: Handlebars.ExceptionNode = {
     loc: {
-      start: {line: 1, column: 5},
-      end: {line: 10, column: 2}
+      start: { line: 1, column: 5 },
+      end: { line: 10, column: 2 }
     }
   };
 

--- a/types/test.ts
+++ b/types/test.ts
@@ -214,6 +214,7 @@ try {
   // Catch exception here.
 }
 
+// Test exception constructor with message and node.
 try {
   const node: Handlebars.ExceptionNode = {
     loc: {

--- a/types/test.ts
+++ b/types/test.ts
@@ -202,41 +202,43 @@ function testParseWithoutProcessing() {
   const parsedTemplateWithoutOptions: hbs.AST.Program = Handlebars.parseWithoutProcessing('<p>Hello, my name is {{name}}.</p>');
 }
 
-// Test exception constructor with just message.
-try {
-  const exp = new Handlebars.Exception('Just a test message.');
-
-  // Assert
-  exp.message === 'Just a test message.' ? 'Passed': 'Failed';
-
-  throw exp;
-} catch(e) {
-  // Catch exception here.
-}
-
-// Test exception constructor with message and node.
-try {
-  const node: Handlebars.ExceptionNode = {
-    loc: {
-      start: { line: 1, column: 5 },
-      end: { line: 10, column: 2 }
-    }
-  };
-
-  const exp = new Handlebars.Exception('Just a test message.', node);
-
-  // Assert
-  exp.message === 'Just a test message.' ? 'Passed': 'Failed';
-  exp.lineNumber === 1 ? 'Passed': 'Failed';
-  exp.column === 5 ? 'Passed': 'Failed';
-  exp.endLineNumber === 10 ? 'Passed': 'Failed';
-  exp.endColumn === 2 ? 'Passed': 'Failed';
-  exp.description; // Could be a string value.
-  exp.name; // Could be a string value. 
-  exp.fileName; // Could be a string value. 
-  exp.stack; // Could be a string value if not undefined.
+function testExceptionTypings() {
+  // Test exception constructor with just message.
+  try {
+    const exp = new Handlebars.Exception('Just a test message.');
   
-  throw exp;
-} catch(e) {
-  // Catch exception here.
+    // Assert
+    exp.message === 'Just a test message.' ? 'Passed': 'Failed';
+  
+    throw exp;
+  } catch(e) {
+    // Catch exception here.
+  }
+  
+  // Test exception constructor with message and node.
+  try {
+    const node: Handlebars.ExceptionNode = {
+      loc: {
+        start: { line: 1, column: 5 },
+        end: { line: 10, column: 2 }
+      }
+    };
+  
+    const exp = new Handlebars.Exception('Just a test message.', node);
+  
+    // Assert
+    exp.message === 'Just a test message.' ? 'Passed': 'Failed';
+    exp.lineNumber === 1 ? 'Passed': 'Failed';
+    exp.column === 5 ? 'Passed': 'Failed';
+    exp.endLineNumber === 10 ? 'Passed': 'Failed';
+    exp.endColumn === 2 ? 'Passed': 'Failed';
+    exp.description; // Could be a string value.
+    exp.name; // Could be a string value. 
+    exp.fileName; // Could be a string value. 
+    exp.stack; // Could be a string value if not undefined.
+    
+    throw exp;
+  } catch(e) {
+    // Catch exception here.
+  }
 }

--- a/types/test.ts
+++ b/types/test.ts
@@ -201,3 +201,41 @@ function testParseWithoutProcessing() {
 
   const parsedTemplateWithoutOptions: hbs.AST.Program = Handlebars.parseWithoutProcessing('<p>Hello, my name is {{name}}.</p>');
 }
+
+// Test exception constructor with just message.
+try {
+  const exp = new Handlebars.Exception('Just a test message.');
+
+  // Assert
+  exp.message === 'Just a test message.' ? 'Passed': 'Failed';
+
+  throw exp;
+} catch(e) {
+  // Catch exception here.
+}
+
+try {
+  const node: Handlebars.ExceptionNode = {
+    loc: {
+      start: {line: 1, column: 5},
+      end: {line: 10, column: 2}
+    }
+  };
+
+  const exp = new Handlebars.Exception('Just a test message.', node);
+
+  // Assert
+  exp.message === 'Just a test message.' ? 'Passed': 'Failed';
+  exp.lineNumber === 1 ? 'Passed': 'Failed';
+  exp.column === 5 ? 'Passed': 'Failed';
+  exp.endLineNumber === 10 ? 'Passed': 'Failed';
+  exp.endColumn === 2 ? 'Passed': 'Failed';
+  exp.description; // Could be a string value.
+  exp.name; // Could be a string value. 
+  exp.fileName; // Could be a string value. 
+  exp.stack; // Could be a string value if not undefined.
+  
+  throw exp;
+} catch(e) {
+  // Catch exception here.
+}

--- a/types/test.ts
+++ b/types/test.ts
@@ -220,7 +220,7 @@ function testExceptionTypings() {
 
 function testExceptionWithNodeTypings() {
   // Test exception constructor with both arguments.
-  const exception = new Handlebars.Exception('Just a test message.', {
+  const exception: Handlebars.Exception = new Handlebars.Exception('Just a test message.', {
     type: 'MustacheStatement',
     loc: {
       source: 'source',

--- a/types/test.ts
+++ b/types/test.ts
@@ -220,7 +220,7 @@ function testExceptionTypings() {
 
 function testExceptionWithNodeTypings() {
   // Test exception constructor with both arguments.
-  const exception: Handlebars.Exception = new Handlebars.Exception('Just a test message.', {
+  const exception: Handlebars.Exception = new Handlebars.Exception('message', {
     type: 'MustacheStatement',
     loc: {
       source: 'source',


### PR DESCRIPTION
Resolves https://github.com/wycats/handlebars.js/issues/1576

Add missing type declarations for the properties of [`Exception`](https://github.com/wycats/handlebars.js/blob/4.x/lib/handlebars/exception.js) class. 

**What has changed?**
 - Converted `function` to a `class` so as to declare fields.
 - Declare all the properties (with the types inferred) that have been attached to the `this` object in the source [file](https://github.com/wycats/handlebars.js/blob/4.x/lib/handlebars/exception.js#L4-L58). 
 - Declare a missing second argument in the typing - `node` of type `hbs.AST.Node`.
 - Add tests for the exception typing. 

---

- [x] Please don't start pull requests for security issues. Instead, file a report at https://www.npmjs.com/advisories/report?package=handlebars
- [x] Maintain the existing code style
- [x] Are focused on a single change (i.e. avoid large refactoring or style adjustments in untouched code if not the primary goal of the pull request)
- [x] Have good commit messages
- [x] Have tests
- [x] Have the [typings](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html) (lib/handlebars.d.ts) updated on every API change. If you need help, updating those, please mention that in the PR description.
- [x] Don't significantly decrease the current code coverage (see coverage/lcov-report/index.html)
- [x] Currently, the `4.x`-branch contains the latest version. Please target that branch in the PR. 

---
@nknapp Not sure if this change requires a test too. If yes, please suggest and show me some examples and I can do it. Thanks!

PS: I tried `npm checkTypes` and `npm test` which all passed for me - not sure what else I need to do. 