### PR TITLE
feat: deprecate custom decorators

### DIFF
--- a/lib/handlebars/base.js
+++ b/lib/handlebars/base.js
@@ -63,6 +63,11 @@ HandlebarsEnvironment.prototype = {
   },
 
   registerDecorator: function(name, fn) {
+    this.log('warn', 'Custom decorators are deprecated and will be removed in the future. Join the discussion at https://github.com/wycats/handlebars.js/issues/1574');
+    this.registerDecoratorWithoutDeprecationWarning(name, fn);
+  },
+
+  registerDecoratorWithoutDeprecationWarning: function(name, fn) {
     if (toString.call(name) === objectType) {
       if (fn) { throw new Exception('Arg not supported with multiple decorators'); }
       extend(this.decorators, name);
@@ -70,6 +75,7 @@ HandlebarsEnvironment.prototype = {
       this.decorators[name] = fn;
     }
   },
+
   unregisterDecorator: function(name) {
     delete this.decorators[name];
   }

--- a/lib/handlebars/decorators/inline.js
+++ b/lib/handlebars/decorators/inline.js
@@ -1,7 +1,7 @@
 import {extend} from '../utils';
 
 export default function(instance) {
-  instance.registerDecorator('inline', function(fn, props, container, options) {
+  instance.registerDecoratorWithoutDeprecationWarning('inline', function(fn, props, container, options) {
     let ret = fn;
     if (!props.partials) {
       props.partials = {};

--- a/spec/blocks.js
+++ b/spec/blocks.js
@@ -306,7 +306,7 @@ describe('blocks', function() {
       equals(run, true);
     });
 
-    describe('registration', function() {
+    describe.only('registration', function() {
       it('unregisters', function() {
         handlebarsEnv.decorators = {};
 


### PR DESCRIPTION
This PR marks the "registerDecorator" is now deprecated. The
decorator API exposes a lot of internal structures that
should not be part of the official API. An alternative
API can be discussed at #1574
- "Handlebars.registerDecorator" now logs a warning
- "Handlebars.registerDecoratorWithoutDeprecationWarning"
  can be used in order to omit the warning, when
  developers have read the notice.
  (The inline-decorator is using this function now)

I would value comments about whether this is the correct way to introduce a deprecation.
My thoughts:
- Pro: People only read a changelog when they have build failures. A deprecation notice in the build 
 log might be more visible than an entry in the release-notes
- Contra: The warning will probably appear in the browser-console of end-users. This may not be
  what developers want. In some cases, developer my have a hard time removing the warnings,
 because they don't have direct access to the code that uses Handlebars. ([like this comment suggests](https://github.com/wycats/handlebars.js/issues/1561#issuecomment-534760915))
- Contra: The message may not be as visible as I intend, if it is just in the build log and in the browser-console.