### PR TITLE
Move eslint-plugin-compat to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "node": ">=0.4.7"
   },
   "dependencies": {
-    "eslint-plugin-compat": "^3.3.0",
     "neo-async": "^2.6.0",
     "optimist": "^0.6.1",
     "source-map": "^0.6.1"
@@ -38,6 +37,7 @@
     "dtslint": "^0.5.5",
     "dustjs-linkedin": "^2.0.2",
     "eco": "~1.1.0-rc-3",
+    "eslint-plugin-compat": "^3.3.0",
     "eslint-plugin-es5": "^1.4.1",
     "grunt": "^1.0.3",
     "grunt-babel": "^5.0.0",


### PR DESCRIPTION
In 088e618 the package `eslint-plugin-compat` was added to `dependencies`, but I expect it was intended to be added to `devDependencies`.  Moving it would save a lot of extra installation for packages that depend on this one.

- [x] Please don't start pull requests for security issues. Instead, file a report at https://www.npmjs.com/advisories/report?package=handlebars
- [x] Maintain the existing code style
- [x] Are focused on a single change (i.e. avoid large refactoring or style adjustments in untouched code if not the primary goal of the pull request)
- [x] Have good commit messages
- [x] Have tests
- [x] Have the [typings](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html) (lib/handlebars.d.ts) updated on every API change. If you need help, updating those, please mention that in the PR description.
- [x] Don't significantly decrease the current code coverage (see coverage/lcov-report/index.html)
- [x] Currently, the `4.x`-branch contains the latest version. Please target that branch in the PR. 