### PR TITLE
fix(runtime.js): partials compile not caching

### DIFF
--- a/lib/handlebars/runtime.js
+++ b/lib/handlebars/runtime.js
@@ -169,7 +169,7 @@ export function template(templateSpec, env) {
     if (!options.partial) {
       container.helpers = Utils.extend({}, env.helpers, options.helpers);
 
-      if (templateSpec.usePartial) {        
+      if (templateSpec.usePartial) {
         // Use merge here to prevent compiling global partials multiple times
         container.partials = container.merge(options.partials, env.partials);
       }

--- a/lib/handlebars/runtime.js
+++ b/lib/handlebars/runtime.js
@@ -161,7 +161,11 @@ export function template(templateSpec, env) {
       container.helpers = Utils.extend({}, env.helpers, options.helpers);
 
       if (templateSpec.usePartial) {
-        container.partials = Utils.extend({}, env.partials, options.partials);
+        if (!options.partials || !env.partials) {
+          container.partials = options.partials || env.partials;
+        } else {
+          container.partials = Utils.extend({}, env.partials, options.partials);
+        }
       }
       if (templateSpec.usePartial || templateSpec.useDecorators) {
         container.decorators = Utils.extend({}, env.decorators, options.decorators);

--- a/lib/handlebars/runtime.js
+++ b/lib/handlebars/runtime.js
@@ -124,7 +124,7 @@ export function template(templateSpec, env) {
       }
       return value;
     },
-    merge: function(param, common) {
+    mergeIfNeeded: function(param, common) {
       let obj = param || common;
 
       if (param && common && (param !== common)) {
@@ -170,8 +170,8 @@ export function template(templateSpec, env) {
       container.helpers = Utils.extend({}, env.helpers, options.helpers);
 
       if (templateSpec.usePartial) {
-        // Use merge here to prevent compiling global partials multiple times
-        container.partials = container.merge(options.partials, env.partials);
+        // Use mergeIfNeeded here to prevent compiling global partials multiple times
+        container.partials = container.mergeIfNeeded(options.partials, env.partials);
       }
       if (templateSpec.usePartial || templateSpec.useDecorators) {
         container.decorators = Utils.extend({}, env.decorators, options.decorators);

--- a/lib/handlebars/runtime.js
+++ b/lib/handlebars/runtime.js
@@ -124,6 +124,15 @@ export function template(templateSpec, env) {
       }
       return value;
     },
+    merge: function(param, common) {
+      let obj = param || common;
+
+      if (param && common && (param !== common)) {
+        obj = Utils.extend({}, common, param);
+      }
+
+      return obj;
+    },
     // An empty object to use as replacement for null-contexts
     nullContext: Object.seal({}),
 
@@ -160,12 +169,9 @@ export function template(templateSpec, env) {
     if (!options.partial) {
       container.helpers = Utils.extend({}, env.helpers, options.helpers);
 
-      if (templateSpec.usePartial) {
-        if (!options.partials || !env.partials) {
-          container.partials = options.partials || env.partials;
-        } else {
-          container.partials = Utils.extend({}, env.partials, options.partials);
-        }
+      if (templateSpec.usePartial) {        
+        // Use merge here to prevent compiling global partials multiple times
+        container.partials = container.merge(options.partials, env.partials);
       }
       if (templateSpec.usePartial || templateSpec.useDecorators) {
         container.decorators = Utils.extend({}, env.decorators, options.decorators);

--- a/spec/compiler.js
+++ b/spec/compiler.js
@@ -108,14 +108,14 @@ describe('compiler', function() {
       equal(/return ""/.test(Handlebars.precompile('')), true);
     });
   });
-  
+
   describe('Compile Partials Correctly', function() {
     var compileCount = 0;
     var origTemplateFunc = Handlebars.template;
     before(function() {
-      Handlebars.template = function(...params) {
+      Handlebars.template = function(params) {
         compileCount++;
-        return origTemplateFunc(...params);
+        return origTemplateFunc(params);
       };
       Handlebars.registerPartial({
         'dude': 'I am a partial'
@@ -123,7 +123,7 @@ describe('compiler', function() {
     });
     after(function() {
       Handlebars.template = origTemplateFunc;
-      // Handlebars.unregisterPartial('dude');
+      Handlebars.unregisterPartial('dude');
     });
 
     it('should only compile global partials once', function() {

--- a/spec/compiler.js
+++ b/spec/compiler.js
@@ -108,29 +108,4 @@ describe('compiler', function() {
       equal(/return ""/.test(Handlebars.precompile('')), true);
     });
   });
-
-  describe('Compile Partials Correctly', function() {
-    var compileCount = 0;
-    var origTemplateFunc = Handlebars.template;
-    before(function() {
-      Handlebars.template = function(params) {
-        compileCount++;
-        return origTemplateFunc(params);
-      };
-      Handlebars.registerPartial({
-        'dude': 'I am a partial'
-      });
-    });
-    after(function() {
-      Handlebars.template = origTemplateFunc;
-      Handlebars.unregisterPartial('dude');
-    });
-
-    it('should only compile global partials once', function() {
-      var string = 'Dudes: {{> dude}} {{> dude}}';
-      Handlebars.compile(string)(); // This should compile template + partial once
-      Handlebars.compile(string)(); // This should only compile template
-      equal(compileCount, 3);
-    });
-  });
 });

--- a/spec/compiler.js
+++ b/spec/compiler.js
@@ -108,4 +108,29 @@ describe('compiler', function() {
       equal(/return ""/.test(Handlebars.precompile('')), true);
     });
   });
+  
+  describe('Compile Partials Correctly', function() {
+    var compileCount = 0;
+    var origTemplateFunc = Handlebars.template;
+    before(function() {
+      Handlebars.template = function(...params) {
+        compileCount++;
+        return origTemplateFunc(...params);
+      };
+      Handlebars.registerPartial({
+        'dude': 'I am a partial'
+      });
+    });
+    after(function() {
+      Handlebars.template = origTemplateFunc;
+      // Handlebars.unregisterPartial('dude');
+    });
+
+    it('should only compile global partials once', function() {
+      var string = 'Dudes: {{> dude}} {{> dude}}';
+      Handlebars.compile(string)(); // This should compile template + partial once
+      Handlebars.compile(string)(); // This should only compile template
+      equal(compileCount, 3);
+    });
+  });
 });

--- a/spec/regressions.js
+++ b/spec/regressions.js
@@ -342,10 +342,10 @@ describe('Regressions', function() {
     }
 
     var newHandlebarsInstance;
-    before(function() {
+    beforeEach(function() {
       newHandlebarsInstance = Handlebars.create();
     });
-    after(function() {
+    afterEach(function() {
       sinon.restore();
     });
 

--- a/spec/regressions.js
+++ b/spec/regressions.js
@@ -334,4 +334,31 @@ describe('Regressions', function() {
 
     shouldCompileTo('{{helpa length="foo"}}', [obj, helpers], 'foo');
   });
+
+  describe('GH-1598: Performance degradation for partials since v4.3.0', function() {
+    // Do not run test for runs without compiler
+    if (!Handlebars.compile) {
+      return;
+    }
+
+    var newHandlebarsInstance;
+    before(function() {
+      newHandlebarsInstance = Handlebars.create();
+    });
+    after(function() {
+      sinon.restore();
+    });
+
+    it('should only compile global partials once', function() {
+      var templateSpy = sinon.spy(newHandlebarsInstance, 'template');
+      newHandlebarsInstance.registerPartial({
+        'dude': 'I am a partial'
+      });
+      var string = 'Dudes: {{> dude}} {{> dude}}';
+      newHandlebarsInstance.compile(string)(); // This should compile template + partial once
+      newHandlebarsInstance.compile(string)(); // This should only compile template
+      equal(templateSpy.callCount, 3);
+      sinon.restore();
+    });
+  });
 });


### PR DESCRIPTION
Reintroduce assigning env.partials to container.partials if no options.partials is set. Also allow assigning options.partials to container.partials if only that one exists. This solves https://github.com/wycats/handlebars.js/issues/1598