### PR TITLE
Add chai and sinon.js + minor fixes in test-methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "handlebars",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -82,6 +82,50 @@
           }
         }
       }
+    },
+    "@sinonjs/commons": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.6.0.tgz",
+      "integrity": "sha512-w4/WHG7C4WWFyE5geCieFJF6MZkbW4VAriol5KlmQXpAQdxvV0p26sqNZOW6Qyw6Y0l9K4g+cHvvczR2sEEpqg==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz",
+      "integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^3.1.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
+      "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.3.0",
+        "array-from": "^2.1.1",
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
     },
     "@types/parsimmon": {
       "version": "1.10.0",
@@ -269,6 +313,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+      "dev": true
+    },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
       "dev": true
     },
     "array-slice": {
@@ -4821,6 +4871,12 @@
         "verror": "1.10.0"
       }
     },
+    "just-extend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
+      "dev": true
+    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -5253,6 +5309,12 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+      "dev": true
+    },
+    "lolex": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
+      "integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==",
       "dev": true
     },
     "longest": {
@@ -5707,6 +5769,36 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y=",
       "dev": true
+    },
+    "nise": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.2.tgz",
+      "integrity": "sha512-/6RhOUlicRCbE9s+94qCUsyE+pKlVJ5AhIv+jEE7ESKwnbXqulKZ1FYU+XAtHHWE9TinYvAxDUJAb912PwPoWA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "lolex": "^4.1.0",
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
     },
     "node-libs-browser": {
       "version": "0.7.0",
@@ -7383,6 +7475,32 @@
       "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz",
       "integrity": "sha1-Krt1qt453rXMgVzhDmGRFkhQuvA=",
       "dev": true
+    },
+    "sinon": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.5.0.tgz",
+      "integrity": "sha512-AoD0oJWerp0/rY9czP/D6hDTTUYGpObhZjMpd7Cl/A6+j0xBE+ayL/ldfggkBXUs0IkvIiM1ljM8+WkOc5k78Q==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.4.0",
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/samsam": "^3.3.3",
+        "diff": "^3.5.0",
+        "lolex": "^4.2.0",
+        "nise": "^1.5.2",
+        "supports-color": "^5.5.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
     },
     "slash": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "handlebars",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -322,6 +322,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
+    },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
     "assign-symbols": {
@@ -985,6 +991,20 @@
         "lazy-cache": "^1.0.3"
       }
     },
+    "chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      }
+    },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
@@ -1002,6 +1022,12 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "dev": true
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
     "chokidar": {
@@ -1467,6 +1493,15 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -1617,6 +1652,12 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
       "integrity": "sha1-gAwN0eCov7yVg1wgKtIg/jF+WhI=",
+      "dev": true
+    },
+    "dirty-chai": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/dirty-chai/-/dirty-chai-2.0.1.tgz",
+      "integrity": "sha512-ys79pWKvDMowIDEPC6Fig8d5THiC0DJ2gmTeGzVAoEH18J8OzLud0Jh7I9IWg3NSk8x2UocznUuFmfHCXYZx9w==",
       "dev": true
     },
     "doctrine": {
@@ -3285,6 +3326,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
       "integrity": "sha1-+Xj6TJDR3+f/LWvtoqUV5xO9z0o=",
+      "dev": true
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
     "get-stdin": {
@@ -6234,6 +6281,12 @@
         "pinkie-promise": "^2.0.0"
       }
     },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
     "pbkdf2-compat": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz",
@@ -8161,6 +8214,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-is": {
       "version": "1.6.16",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "babel-loader": "^5.0.0",
     "babel-runtime": "^5.1.10",
     "benchmark": "~1.0",
+    "chai": "^4.2.0",
+    "dirty-chai": "^2.0.1",
     "dtslint": "^0.5.5",
     "dustjs-linkedin": "^2.0.2",
     "eco": "~1.1.0-rc-3",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "mock-stdin": "^0.3.0",
     "mustache": "^2.1.3",
     "semver": "^5.0.1",
+    "sinon": "^7.5.0",
     "typescript": "^3.4.3",
     "underscore": "^1.5.1",
     "webpack": "^1.12.6",

--- a/spec/.eslintrc
+++ b/spec/.eslintrc
@@ -28,15 +28,18 @@
     "stop": true,
     "ok": true,
     "strictEqual": true,
-    "define": true
+    "define": true,
+    "expect": true,
+    "chai": true
   },
   "env": {
     "mocha": true
   },
   "rules": {
     // Disabling for tests, for now.
-    "no-path-concat": 0,
+    "no-path-concat": "off",
 
-    "no-var": 0
+    "no-var": "off",
+    "dot-notation": "off"
   }
 }

--- a/spec/amd-runtime.html
+++ b/spec/amd-runtime.html
@@ -18,11 +18,14 @@
         document.documentElement.className = 'headless';
       }
     </script>
+    <script src="/node_modules/sinon/pkg/sinon.js"></script>
+    <script src="/node_modules/chai/chai.js"></script>
+    <script src="/node_modules/dirty-chai/lib/dirty-chai.js"></script>
     <script src="/node_modules/mocha/mocha.js"></script>
     <script>
+      window.expect = chai.expect;
       mocha.setup('bdd');
     </script>
-
     <script src="/spec/env/json2.js"></script>
     <script src="/spec/env/require.js"></script>
 

--- a/spec/amd.html
+++ b/spec/amd.html
@@ -19,11 +19,14 @@
         document.documentElement.className = 'headless';
       }
     </script>
+    <script src="/node_modules/sinon/pkg/sinon.js"></script>
+    <script src="/node_modules/chai/chai.js"></script>
+    <script src="/node_modules/dirty-chai/lib/dirty-chai.js"></script>
     <script src="/node_modules/mocha/mocha.js"></script>
     <script>
+      window.expect = chai.expect;
       mocha.setup('bdd');
     </script>
-
     <script src="/spec/env/json2.js"></script>
     <script src="/spec/env/require.js"></script>
 

--- a/spec/env/browser.js
+++ b/spec/env/browser.js
@@ -3,6 +3,15 @@ require('./common');
 var fs = require('fs'),
     vm = require('vm');
 
+var chai = require('chai');
+var dirtyChai = require('dirty-chai');
+
+
+chai.use(dirtyChai);
+global.expect = chai.expect;
+
+global.sinon = require('sinon');
+
 global.Handlebars = 'no-conflict';
 
 var filename = 'dist/handlebars.js';

--- a/spec/env/common.js
+++ b/spec/env/common.js
@@ -63,12 +63,20 @@ global.compileWithPartials = function(string, hashOrArray, partials) {
 };
 
 
+/**
+ * @deprecated Use chai's expect-style API instead (`expect(actualValue).to.equal(expectedValue)`)
+ * @see https://www.chaijs.com/api/bdd/
+ */
 global.equals = global.equal = function equals(a, b, msg) {
   if (a !== b) {
     throw new AssertError("'" + a + "' should === '" + b + "'" + (msg ? ': ' + msg : ''), equals);
   }
 };
 
+/**
+ * @deprecated Use chai's expect-style API instead (`expect(actualValue).to.equal(expectedValue)`)
+ * @see https://www.chaijs.com/api/bdd/#method_throw
+ */
 global.shouldThrow = function(callback, type, msg) {
   var failed;
   try {

--- a/spec/env/node.js
+++ b/spec/env/node.js
@@ -1,5 +1,11 @@
 require('./common');
 
+var chai = require('chai');
+var dirtyChai = require('dirty-chai');
+
+chai.use(dirtyChai);
+global.expect = chai.expect;
+
 global.Handlebars = require('../../lib');
 
 global.CompilerContext = {

--- a/spec/env/node.js
+++ b/spec/env/node.js
@@ -3,8 +3,11 @@ require('./common');
 var chai = require('chai');
 var dirtyChai = require('dirty-chai');
 
+
 chai.use(dirtyChai);
 global.expect = chai.expect;
+
+global.sinon = require('sinon');
 
 global.Handlebars = require('../../lib');
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -20,6 +20,8 @@
       }
     </script>
     <script src="/node_modules/mocha/mocha.js"></script>
+    <script src="/node_modules/chai/chai.js"></script>
+    <script src="/node_modules/dirty-chai/lib/dirty-chai.js"></script>
     <script>
       mocha.setup('bdd');
     </script>

--- a/spec/index.html
+++ b/spec/index.html
@@ -19,14 +19,15 @@
         document.documentElement.className = 'headless';
       }
     </script>
-    <script src="/node_modules/mocha/mocha.js"></script>
+    <script src="/node_modules/sinon/pkg/sinon.js"></script>
     <script src="/node_modules/chai/chai.js"></script>
     <script src="/node_modules/dirty-chai/lib/dirty-chai.js"></script>
+    <script src="/node_modules/mocha/mocha.js"></script>
     <script>
+      window.expect = chai.expect;
       mocha.setup('bdd');
     </script>
     <script src="/dist/handlebars.js"></script>
-
     <script src="/spec/env/json2.js"></script>
     <script src="/spec/env/common.js"></script>
     <script>

--- a/spec/security.js
+++ b/spec/security.js
@@ -75,11 +75,11 @@ describe('security issues', function() {
             });
             it('should throw an exception when calling  "{{blockHelperMissing "abc" .}}" ', function() {
                 var functionCalls = [];
-                shouldThrow(function() {
+                expect(function() {
                     var template = Handlebars.compile('{{blockHelperMissing "abc" .}}');
                     template({ fn: function() { functionCalls.push('called'); }});
-                }, Error);
-                equals(functionCalls.length, 0);
+                }).to.throw(Error);
+                expect(functionCalls.length).to.equal(0);
             });
             it('should throw an exception when calling  "{{#blockHelperMissing .}}{{/blockHelperMissing}}"', function() {
                 shouldThrow(function() {

--- a/spec/umd-runtime.html
+++ b/spec/umd-runtime.html
@@ -18,11 +18,14 @@
         document.documentElement.className = 'headless';
       }
     </script>
+    <script src="/node_modules/sinon/pkg/sinon.js"></script>
+    <script src="/node_modules/chai/chai.js"></script>
+    <script src="/node_modules/dirty-chai/lib/dirty-chai.js"></script>
     <script src="/node_modules/mocha/mocha.js"></script>
     <script>
+      window.expect = chai.expect;
       mocha.setup('bdd');
     </script>
-
     <script src="/spec/env/json2.js"></script>
     <script src="/spec/env/require.js"></script>
 

--- a/spec/umd.html
+++ b/spec/umd.html
@@ -18,11 +18,15 @@
         document.documentElement.className = 'headless';
       }
     </script>
+
+    <script src="/node_modules/sinon/pkg/sinon.js"></script>
+    <script src="/node_modules/chai/chai.js"></script>
+    <script src="/node_modules/dirty-chai/lib/dirty-chai.js"></script>
     <script src="/node_modules/mocha/mocha.js"></script>
     <script>
+      window.expect = chai.expect;
       mocha.setup('bdd');
     </script>
-
     <script src="/spec/env/json2.js"></script>
     <script src="/spec/env/require.js"></script>
 

--- a/tasks/test.js
+++ b/tasks/test.js
@@ -33,7 +33,7 @@ module.exports = function(grunt) {
 
     var runner = childProcess.fork('./spec/env/runner', [], {stdio: 'inherit'});
     runner.on('close', function(code) {
-      if (code != 0) {
+      if (code !== 0) {
         grunt.fatal(code + ' tests failed');
       }
       done();
@@ -55,7 +55,7 @@ module.exports = function(grunt) {
 
     var runner = childProcess.fork('./spec/env/runner', ['--min'], {stdio: 'inherit'});
     runner.on('close', function(code) {
-      if (code != 0) {
+      if (code !== 0) {
         grunt.fatal(code + ' tests failed');
       }
       done();


### PR DESCRIPTION
* I added minor fixes (use of `!==` instead of `!=`) to sthe test-tasks (not production code)
* I added chai.js and sinon.js and included `expect` and `sinon` as global variables.
  * https://sinonjs.org/releases/v7.5.0/
  * https://www.chaijs.com/api/bdd/
  The goal is to use those libraries for assertions and spies in the future, in contrast to the 
  hand-built ones
* deprecation notices added to all other test methods