### PR TITLE
fix: add more properties required to be enumerable

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -57,6 +57,7 @@ module.exports = {
     "no-with": "error",
     "radix": "error",
     "wrap-iife": "error",
+    "no-prototype-builtins": "error",
 
 
     // Variables //
@@ -114,4 +115,4 @@ module.exports = {
     "ecmaVersion": 6,
     "ecmaFeatures": {}
   }
-}
+};

--- a/bench/util/benchwarmer.js
+++ b/bench/util/benchwarmer.js
@@ -29,7 +29,7 @@ BenchWarmer.prototype = {
     });
   },
   push: function(name, fn) {
-    if (this.names.indexOf(name) == -1) {
+    if (this.names.indexOf(name) === -1) {
       this.names.push(name);
     }
 
@@ -77,7 +77,7 @@ BenchWarmer.prototype = {
 
         var errors = false, prop, bench;
         for (prop in self.errors) {
-          if (self.errors.hasOwnProperty(prop)
+          if (Object.prototype.hasOwnProperty.call(self, prop)
               && self.errors[prop].error.message !== 'EWOT') {
             errors = true;
             break;
@@ -86,9 +86,8 @@ BenchWarmer.prototype = {
 
         if (errors) {
           print('\n\nErrors:\n');
-          for (prop in self.errors) {
-            if (self.errors.hasOwnProperty(prop)
-                && self.errors[prop].error.message !== 'EWOT') {
+          Object.keys(self.errors).forEach(function(prop) {
+            if (self.errors[prop].error.message !== 'EWOT') {
               bench = self.errors[prop];
               print('\n' + bench.name + ':\n');
               print(bench.error.message);
@@ -97,7 +96,7 @@ BenchWarmer.prototype = {
               }
               print('\n');
             }
-          }
+          });
         }
 
         callback();

--- a/lib/handlebars/compiler/code-gen.js
+++ b/lib/handlebars/compiler/code-gen.js
@@ -125,14 +125,12 @@ CodeGen.prototype = {
   objectLiteral: function(obj) {
     let pairs = [];
 
-    for (let key in obj) {
-      if (obj.hasOwnProperty(key)) {
-        let value = castChunk(obj[key], this);
-        if (value !== 'undefined') {
-          pairs.push([this.quotedString(key), ':', value]);
-        }
+    Object.keys(obj).forEach(key => {
+      let value = castChunk(obj[key], this);
+      if (value !== 'undefined') {
+        pairs.push([this.quotedString(key), ':', value]);
       }
-    }
+    });
 
     let ret = this.generateList(pairs);
     ret.prepend('{');

--- a/lib/handlebars/compiler/compiler.js
+++ b/lib/handlebars/compiler/compiler.js
@@ -54,9 +54,7 @@ Compiler.prototype = {
 
     options.blockParams = options.blockParams || [];
 
-    // These changes will propagate to the other compiler components
-    let knownHelpers = options.knownHelpers;
-    options.knownHelpers = {
+    options.knownHelpers = extend(Object.create(null), {
       'helperMissing': true,
       'blockHelperMissing': true,
       'each': true,
@@ -65,15 +63,7 @@ Compiler.prototype = {
       'with': true,
       'log': true,
       'lookup': true
-    };
-    if (knownHelpers) {
-      // the next line should use "Object.keys", but the code has been like this a long time and changing it, might
-      // cause backwards-compatibility issues... It's an old library...
-      // eslint-disable-next-line guard-for-in
-      for (let name in knownHelpers) {
-          this.options.knownHelpers[name] = knownHelpers[name];
-      }
-    }
+    }, options.knownHelpers);
 
     return this.accept(program);
   },
@@ -369,7 +359,6 @@ Compiler.prototype = {
     if (isEligible && !isHelper) {
       let name = sexpr.path.parts[0],
           options = this.options;
-
       if (options.knownHelpers[name]) {
         isHelper = true;
       } else if (options.knownHelpersOnly) {

--- a/lib/handlebars/compiler/javascript-compiler.js
+++ b/lib/handlebars/compiler/javascript-compiler.js
@@ -218,13 +218,13 @@ JavaScriptCompiler.prototype = {
     // aliases will not be used, but this case is already being run on the client and
     // we aren't concern about minimizing the template size.
     let aliasCount = 0;
-    for (let alias in this.aliases) { // eslint-disable-line guard-for-in
+    Object.keys(this.aliases).forEach(alias => {
       let node = this.aliases[alias];
-      if (this.aliases.hasOwnProperty(alias) && node.children && node.referenceCount > 1) {
+      if (node.children && node.referenceCount > 1) {
         varDeclarations += ', alias' + (++aliasCount) + '=' + alias;
         node.children[0] = 'alias' + aliasCount;
       }
-    }
+    });
 
     let params = ['container', 'depth0', 'helpers', 'partials', 'data'];
 

--- a/lib/handlebars/compiler/javascript-compiler.js
+++ b/lib/handlebars/compiler/javascript-compiler.js
@@ -2,6 +2,7 @@ import { COMPILER_REVISION, REVISION_CHANGES } from '../base';
 import Exception from '../exception';
 import {isArray} from '../utils';
 import CodeGen from './code-gen';
+import {dangerousPropertyRegex} from '../helpers/lookup';
 
 function Literal(value) {
   this.value = value;
@@ -13,9 +14,8 @@ JavaScriptCompiler.prototype = {
   // PUBLIC API: You can override these methods in a subclass to provide
   // alternative compiled forms for name lookup and buffering semantics
   nameLookup: function(parent, name/* , type*/) {
-    const isEnumerable = [ this.aliasable('container.propertyIsEnumerable'), '.call(', parent, ',"constructor")'];
-
-    if (name === 'constructor') {
+    if (dangerousPropertyRegex.test(name)) {
+      const isEnumerable = [ this.aliasable('container.propertyIsEnumerable'), '.call(', parent, ',', JSON.stringify(name), ')'];
       return ['(', isEnumerable, '?', _actualLookup(), ' : undefined)'];
     }
     return _actualLookup();

--- a/lib/handlebars/helpers/each.js
+++ b/lib/handlebars/helpers/each.js
@@ -62,18 +62,16 @@ export default function(instance) {
       } else {
         let priorKey;
 
-        for (let key in context) {
-          if (context.hasOwnProperty(key)) {
-            // We're running the iterations one step out of sync so we can detect
-            // the last iteration without have to scan the object twice and create
-            // an itermediate keys array.
-            if (priorKey !== undefined) {
-              execIteration(priorKey, i - 1);
-            }
-            priorKey = key;
-            i++;
+        Object.keys(context).forEach(key => {
+          // We're running the iterations one step out of sync so we can detect
+          // the last iteration without have to scan the object twice and create
+          // an itermediate keys array.
+          if (priorKey !== undefined) {
+            execIteration(priorKey, i - 1);
           }
-        }
+          priorKey = key;
+          i++;
+        });
         if (priorKey !== undefined) {
           execIteration(priorKey, i - 1, true);
         }

--- a/lib/handlebars/helpers/lookup.js
+++ b/lib/handlebars/helpers/lookup.js
@@ -1,9 +1,11 @@
+export const dangerousPropertyRegex = /^(constructor|__defineGetter__|__defineSetter__|__lookupGetter__|__proto__)$/;
+
 export default function(instance) {
   instance.registerHelper('lookup', function(obj, field) {
     if (!obj) {
       return obj;
     }
-    if (String(field) === 'constructor' && !obj.propertyIsEnumerable(field)) {
+    if (dangerousPropertyRegex.test(String(field)) && !obj.propertyIsEnumerable(field)) {
       return undefined;
     }
     return obj[field];

--- a/lib/handlebars/helpers/lookup.js
+++ b/lib/handlebars/helpers/lookup.js
@@ -5,7 +5,7 @@ export default function(instance) {
     if (!obj) {
       return obj;
     }
-    if (dangerousPropertyRegex.test(String(field)) && !obj.propertyIsEnumerable(field)) {
+    if (dangerousPropertyRegex.test(String(field)) && !Object.prototype.propertyIsEnumerable.call(obj, field)) {
       return undefined;
     }
     return obj[field];

--- a/spec/compiler.js
+++ b/spec/compiler.js
@@ -59,7 +59,7 @@ describe('compiler', function() {
         Handlebars.compile(' \n  {{#if}}\n{{/def}}')();
         equal(true, false, 'Statement must throw exception. This line should not be executed.');
       } catch (err) {
-        equal(err.propertyIsEnumerable('column'), true, 'Checking error column');
+        equal(Object.prototype.propertyIsEnumerable.call(err, 'column'), true, 'Checking error column');
       }
     });
 

--- a/spec/regressions.js
+++ b/spec/regressions.js
@@ -211,12 +211,12 @@ describe('Regressions', function() {
         // It's valid to execute a block against an undefined context, but
         // helpers can not do so, so we expect to have an empty object here;
         for (var name in this) {
-          if (this.hasOwnProperty(name)) {
+          if (Object.prototype.hasOwnProperty.call(this, name)) {
             return 'found';
           }
         }
         // And to make IE happy, check for the known string as length is not enumerated.
-        return (this == 'bat' ? 'found' : 'not');
+        return (this === 'bat' ? 'found' : 'not');
       }
     };
 

--- a/spec/security.js
+++ b/spec/security.js
@@ -114,13 +114,31 @@ describe('security issues', function() {
     describe('GH-1563', function() {
         it('should not allow to access constructor after overriding via __defineGetter__', function() {
             if (({}).__defineGetter__ == null || ({}).__lookupGetter__ == null) {
-                return; // Browser does not support this exploit anyway
+                return this.skip(); // Browser does not support this exploit anyway
             }
-            shouldCompileTo('{{__defineGetter__ "undefined" valueOf }}' +
+            expectTemplate('{{__defineGetter__ "undefined" valueOf }}' +
                 '{{#with __lookupGetter__ }}' +
                 '{{__defineGetter__ "propertyIsEnumerable" (this.bind (this.bind 1)) }}' +
                 '{{constructor.name}}' +
-                '{{/with}}', {}, '');
+                '{{/with}}')
+                .withInput({})
+                .toThrow(/Missing helper: "__defineGetter__"/);
         });
+    });
+
+    describe('GH-1595', function() {
+      it('properties, that are required to be enumerable', function() {
+        expectTemplate('{{constructor}}').withInput({}).toCompileTo('');
+        expectTemplate('{{__defineGetter__}}').withInput({}).toCompileTo('');
+        expectTemplate('{{__defineSetter__}}').withInput({}).toCompileTo('');
+        expectTemplate('{{__lookupGetter__}}').withInput({}).toCompileTo('');
+        expectTemplate('{{__proto__}}').withInput({}).toCompileTo('');
+
+        expectTemplate('{{lookup "constructor"}}').withInput({}).toCompileTo('');
+        expectTemplate('{{lookup "__defineGetter__"}}').withInput({}).toCompileTo('');
+        expectTemplate('{{lookup "__defineSetter__"}}').withInput({}).toCompileTo('');
+        expectTemplate('{{lookup "__lookupGetter__"}}').withInput({}).toCompileTo('');
+        expectTemplate('{{lookup "__proto__"}}').withInput({}).toCompileTo('');
+      });
     });
 });


### PR DESCRIPTION
This commit adds a blacklist of properties that are required to be enumerable.

In addition to **constructor**, the properties **__defineGetter__**, **__defineSetter__**, **__lookupGetter__** and **__proto__** are now considered harmful.

This is only the first step to resolve #1595 the next version will probably be a whitelist instead of a blacklist, but this needs more consideration.

There exist exploits that are fixed by this change, which is why I would like to do this quickly.

Update: I also added the "no-prototype-builtins" eslint-rule because this was also part of the exploits.
