### PR TITLE
Update readme.md with updated links

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -51,7 +51,7 @@ Full documentation and more examples are at [handlebarsjs.com](https://handlebar
 Precompiling Templates
 ----------------------
 
-Handlebars allows templates to be precompiled and included as javascript code rather than the handlebars template allowing for faster startup time. Full details are located [here](https://handlebars-archive.knappi.org/precompilation.html).
+Handlebars allows templates to be precompiled and included as javascript code rather than the handlebars template allowing for faster startup time. Full details are located [here](https://handlebarsjs.com/installation/precompilation.html).
 
 Differences Between Handlebars.js and Mustache
 ----------------------------------------------

--- a/README.markdown
+++ b/README.markdown
@@ -51,7 +51,7 @@ Full documentation and more examples are at [handlebarsjs.com](https://handlebar
 Precompiling Templates
 ----------------------
 
-Handlebars allows templates to be precompiled and included as javascript code rather than the handlebars template allowing for faster startup time. Full details are located [here](https://handlebarsjs.com/precompilation/).
+Handlebars allows templates to be precompiled and included as javascript code rather than the handlebars template allowing for faster startup time. Full details are located [here](https://handlebars-archive.knappi.org/precompilation.html).
 
 Differences Between Handlebars.js and Mustache
 ----------------------------------------------

--- a/README.markdown
+++ b/README.markdown
@@ -11,12 +11,12 @@ Handlebars.js and Mustache are both logicless templating languages that
 keep the view and the code separated like we all know they should be.
 
 Checkout the official Handlebars docs site at
-[http://www.handlebarsjs.com](http://www.handlebarsjs.com) and the live demo at [http://tryhandlebarsjs.com/](http://tryhandlebarsjs.com/).
+[https://handlebarsjs.com/](https://handlebarsjs.com) and the live demo at [http://tryhandlebarsjs.com/](http://tryhandlebarsjs.com/).
 
 Installing
 ----------
 
-See our [installation documentation](http://handlebarsjs.com/installation.html).
+See our [installation documentation](https://handlebarsjs.com/installation/).
 
 Usage
 -----
@@ -46,23 +46,23 @@ var result = template(data);
 // </ul>
 ```
 
-Full documentation and more examples are at [handlebarsjs.com](http://handlebarsjs.com/).
+Full documentation and more examples are at [handlebarsjs.com](https://handlebarsjs.com/).
 
 Precompiling Templates
 ----------------------
 
-Handlebars allows templates to be precompiled and included as javascript code rather than the handlebars template allowing for faster startup time. Full details are located [here](http://handlebarsjs.com/precompilation.html).
+Handlebars allows templates to be precompiled and included as javascript code rather than the handlebars template allowing for faster startup time. Full details are located [here](https://handlebarsjs.com/precompilation/).
 
 Differences Between Handlebars.js and Mustache
 ----------------------------------------------
 Handlebars.js adds a couple of additional features to make writing
 templates easier and also changes a tiny detail of how partials work.
 
-- [Nested Paths](http://handlebarsjs.com/#paths)
-- [Helpers](http://handlebarsjs.com/#helpers)
-- [Block Expressions](http://handlebarsjs.com/#block-expressions)
-- [Literal Values](http://handlebarsjs.com/#literals)
-- [Delimited Comments](http://handlebarsjs.com/#comments)
+- [Nested Paths](https://handlebarsjs.com/guide/expressions.html#path-expressions)
+- [Helpers](https://handlebarsjs.com/guide/expressions.html#helpers)
+- [Block Expressions](https://handlebarsjs.com/guide/block-helpers.html#basic-blocks)
+- [Literal Values](https://handlebarsjs.com/guide/expressions.html#literal-segments)
+- [Delimited Comments](https://handlebarsjs.com/guide/#template-comments)
 
 Block expressions have the same syntax as mustache sections but should not be confused with one another. Sections are akin to an implicit `each` or `with` statement depending on the input data and helpers are explicit pieces of code that are free to implement whatever behavior they like. The [mustache spec](http://mustache.github.io/mustache.5.html) defines the exact behavior of sections. In the case of name conflicts, helpers are given priority.
 


### PR DESCRIPTION
I noticed there was several dead links in the readme due to the new doc being released. Updated links to their new locations
Fix http->https where possible and update links doc links.
Fixes issue: https://github.com/wycats/handlebars.js/issues/1616