### PR TITLE
test: fix integration tests

### DIFF
--- a/integration-testing/multi-nodejs-test/test.sh
+++ b/integration-testing/multi-nodejs-test/test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 cd "$( dirname "$( readlink -f "$0" )" )" || exit 1
 # shellcheck disable=SC1090
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
@@ -20,8 +22,8 @@ for i in  0.10 0.12 4 5 6 7 8 9 10 11 ; do
     mkdir target
     nvm install "$i"
     nvm exec "$i" npm install
-    nvm exec "$i" npm run test || exit 1
-    nvm exec "$i" npm run test-precompile || exit 1
+    nvm exec "$i" npm run test
+    nvm exec "$i" npm run test-precompile
 
     echo Success
 done

--- a/integration-testing/run-integration-tests.sh
+++ b/integration-testing/run-integration-tests.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 
-cd "$( dirname "$( readlink -f "$0" )" )" || exit 1
+set -e
+
+cd "$( dirname "$( readlink -f "$0" )" )"
 
 for i in */test.sh ; do
   (
     echo "----------------------------------------"
     echo "-- Running integration test: $i"
     echo "----------------------------------------"
-    cd "$( dirname "$i" )" || exit 1
-    ./test.sh || exit 1
+    cd "$( dirname "$i" )"
+    ./test.sh
   )
 done

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "handlebars",
-  "version": "4.7.3",
+  "version": "4.7.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Ensure that integration tests fail, if a single test fails
The build for this PR will fail, if the tests are fixed correctly, because the `yargs` upgrade is incompatible to older node versions.