### PR TITLE
chore: update type testing setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lint": "npm run lint:oxlint && npm run lint:format && npm run lint:types && npm run lint:compat",
     "lint:oxlint": "oxlint --max-warnings 0 .",
     "lint:format": "oxfmt --check .",
-    "lint:types": "tsc --noEmit --project types && tstyche",
+    "lint:types": "tstyche",
     "lint:compat": "eslint",
     "test": "npm run build && vitest run --project node --project tasks --project rspack --coverage",
     "test:browser": "vitest run --project browser",

--- a/tstyche.config.json
+++ b/tstyche.config.json
@@ -1,4 +1,0 @@
-{
-  "testFileMatch": ["types/__typetests__/**/*.tst.ts"],
-  "tsconfig": "./types/tsconfig.json"
-}

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -2,16 +2,14 @@
   "compilerOptions": {
     "module": "commonjs",
     "lib": ["es6"],
-    "noImplicitAny": true,
-    "noImplicitThis": true,
-    "strictNullChecks": true,
-    "strictFunctionTypes": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
+    "strict": true,
     "noEmit": true,
 
-    "baseUrl": ".",
     "types": [],
     "paths": {
-      "handlebars": ["."]
+      "handlebars": ["../"]
     }
   }
 }


### PR DESCRIPTION
Glad to see you found TSTyche useful. I am its author.

This PR updates and cleans up the type testing setup. I would suggest the following:

- removing `tstyche.config.json`, because TSTyche does all what is defined the by default;
- making `types/tsconfig.json` stricter;
- and removing `tsc` from the `lint:types` script, because `tstyche` does check the same files files as `tsc`.

