### PR TITLE
[4.x] Fix release script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,9 +132,11 @@ A full release via Docker may be completed with the following:
     
     # Generate config for yo generator-release:
     # https://github.com/kpdecker/generator-release#example
-    # You have to add a valid GitHub OAuth token!
-    RUN echo "module.exports = {\n  auth: 'oauth',\n  token: 'GitHub OAuth token'\n};" > /home/node/.config/generator-release
+    # You have to add a valid GitHub access token! (Used for reading issues and pull requests.)
+    RUN echo "module.exports = {\n  auth: 'oauth',\n  token: 'GitHub personal access token'\n};" > /home/node/.config/generator-release
     RUN chown -R node:node /home/node/.config
+    RUN chown -R node:node /home/node/.ssh
+    RUN chown -R node:node /home/node/tmp
     
     # Add the generated key to GitHub: https://github.com/settings/keys
     RUN ssh-keygen -q -t ed25519 -N '' -f /home/node/.ssh/id_ed25519 -C "release@handlebarsjs.com"
@@ -155,9 +157,12 @@ A full release via Docker may be completed with the following:
    * Add GitHub API token: `vi /home/node/.config/generator-release`
    * Execute the following steps:
      ```bash
-     npm ci
+     npm install
      npm install -g yo@1 grunt@1 generator-release
      npm run release
+     # Warning! This step will collect data from GitHub, bump the version,
+     # create a new commit, create a new tag and push it to GitHub.
+     # https://github.com/kpdecker/generator-release?tab=readme-ov-file#usage
      yo release
      npm login
      npm publish

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "eslint-plugin-compat": "^3.13.0",
         "eslint-plugin-es5": "^1.4.1",
         "fs-extra": "^8.1.0",
-        "grunt": "^1.0.4",
+        "grunt": "1.5.3",
         "grunt-babel": "^5.0.0",
         "grunt-cli": "^1",
         "grunt-contrib-clean": "^1",
@@ -1098,17 +1098,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/body-parser/node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/body-parser/node_modules/on-finished": {
       "version": "2.4.1",
       "dev": true,
@@ -1813,17 +1802,6 @@
         "node": "*"
       }
     },
-    "node_modules/commoner/node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/commoner/node_modules/recast": {
       "version": "0.11.23",
       "dev": true,
@@ -2231,7 +2209,9 @@
       }
     },
     "node_modules/dateformat": {
-      "version": "4.6.3",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3420,17 +3400,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/external-editor/node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/extglob": {
       "version": "0.3.2",
       "dev": true,
@@ -3740,70 +3709,33 @@
       }
     },
     "node_modules/findup-sync": {
-      "version": "5.0.0",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
+      "integrity": "sha512-z8Nrwhi6wzxNMIbxlrTzuUW6KWuKkogZ/7OdDVq+0+kxn77KUH1nipx8iU6suqkHqc4y6n7a9A8IpmxY/pTjWg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "detect-file": "^1.0.0",
-        "is-glob": "^4.0.3",
-        "micromatch": "^4.0.4",
-        "resolve-dir": "^1.0.1"
+        "glob": "~5.0.0"
       },
       "engines": {
-        "node": ">= 10.13.0"
+        "node": ">= 0.6.0"
       }
     },
-    "node_modules/findup-sync/node_modules/braces": {
-      "version": "3.0.3",
+    "node_modules/findup-sync/node_modules/glob": {
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+      "integrity": "sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
-      "license": "MIT",
+      "license": "ISC",
       "dependencies": {
-        "fill-range": "^7.1.1"
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "2 || 3",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       },
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/findup-sync/node_modules/fill-range": {
-      "version": "7.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/findup-sync/node_modules/is-extglob": {
-      "version": "2.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/findup-sync/node_modules/is-glob": {
-      "version": "4.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-extglob": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/findup-sync/node_modules/micromatch": {
-      "version": "4.0.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
+        "node": "*"
       }
     },
     "node_modules/fined": {
@@ -4296,29 +4228,33 @@
       }
     },
     "node_modules/grunt": {
-      "version": "1.6.1",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.5.3.tgz",
+      "integrity": "sha512-mKwmo4X2d8/4c/BmcOETHek675uOqw0RuA/zy12jaspWqvTp4+ZeQF1W+OTpcbncnaBsfbQJ6l0l4j+Sn/GmaQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "dateformat": "~4.6.2",
+        "dateformat": "~3.0.3",
         "eventemitter2": "~0.4.13",
         "exit": "~0.1.2",
-        "findup-sync": "~5.0.0",
+        "findup-sync": "~0.3.0",
         "glob": "~7.1.6",
         "grunt-cli": "~1.4.3",
         "grunt-known-options": "~2.0.0",
         "grunt-legacy-log": "~3.0.0",
         "grunt-legacy-util": "~2.0.1",
-        "iconv-lite": "~0.6.3",
+        "iconv-lite": "~0.4.13",
         "js-yaml": "~3.14.0",
         "minimatch": "~3.0.4",
-        "nopt": "~3.0.6"
+        "mkdirp": "~1.0.4",
+        "nopt": "~3.0.6",
+        "rimraf": "~3.0.2"
       },
       "bin": {
         "grunt": "bin/grunt"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=8"
       }
     },
     "node_modules/grunt-babel": {
@@ -4892,6 +4828,36 @@
         "node": "*"
       }
     },
+    "node_modules/grunt/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/grunt/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/grunt/node_modules/v8flags": {
       "version": "3.2.0",
       "dev": true,
@@ -5311,11 +5277,13 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.6.3",
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
+        "safer-buffer": ">= 2.1.2 < 3"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -12389,13 +12357,6 @@
             "toidentifier": "~1.0.1"
           }
         },
-        "iconv-lite": {
-          "version": "0.4.24",
-          "dev": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
-        },
         "on-finished": {
           "version": "2.4.1",
           "dev": true,
@@ -12858,13 +12819,6 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "iconv-lite": {
-          "version": "0.4.24",
-          "dev": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
-        },
         "recast": {
           "version": "0.11.23",
           "dev": true,
@@ -13128,7 +13082,9 @@
       }
     },
     "dateformat": {
-      "version": "4.6.3",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
       "dev": true
     },
     "debug": {
@@ -13893,15 +13849,6 @@
         "chardet": "^0.7.0",
         "iconv-lite": "^0.4.24",
         "tmp": "^0.0.33"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.4.24",
-          "dev": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
-        }
       }
     },
     "extglob": {
@@ -14111,46 +14058,25 @@
       }
     },
     "findup-sync": {
-      "version": "5.0.0",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
+      "integrity": "sha512-z8Nrwhi6wzxNMIbxlrTzuUW6KWuKkogZ/7OdDVq+0+kxn77KUH1nipx8iU6suqkHqc4y6n7a9A8IpmxY/pTjWg==",
       "dev": true,
       "requires": {
-        "detect-file": "^1.0.0",
-        "is-glob": "^4.0.3",
-        "micromatch": "^4.0.4",
-        "resolve-dir": "^1.0.1"
+        "glob": "~5.0.0"
       },
       "dependencies": {
-        "braces": {
-          "version": "3.0.3",
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==",
           "dev": true,
           "requires": {
-            "fill-range": "^7.1.1"
-          }
-        },
-        "fill-range": {
-          "version": "7.1.1",
-          "dev": true,
-          "requires": {
-            "to-regex-range": "^5.0.1"
-          }
-        },
-        "is-extglob": {
-          "version": "2.1.1",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "4.0.3",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^2.1.1"
-          }
-        },
-        "micromatch": {
-          "version": "4.0.8",
-          "dev": true,
-          "requires": {
-            "braces": "^3.0.3",
-            "picomatch": "^2.3.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -14472,22 +14398,26 @@
       "dev": true
     },
     "grunt": {
-      "version": "1.6.1",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.5.3.tgz",
+      "integrity": "sha512-mKwmo4X2d8/4c/BmcOETHek675uOqw0RuA/zy12jaspWqvTp4+ZeQF1W+OTpcbncnaBsfbQJ6l0l4j+Sn/GmaQ==",
       "dev": true,
       "requires": {
-        "dateformat": "~4.6.2",
+        "dateformat": "~3.0.3",
         "eventemitter2": "~0.4.13",
         "exit": "~0.1.2",
-        "findup-sync": "~5.0.0",
+        "findup-sync": "~0.3.0",
         "glob": "~7.1.6",
         "grunt-cli": "~1.4.3",
         "grunt-known-options": "~2.0.0",
         "grunt-legacy-log": "~3.0.0",
         "grunt-legacy-util": "~2.0.1",
-        "iconv-lite": "~0.6.3",
+        "iconv-lite": "~0.4.13",
         "js-yaml": "~3.14.0",
         "minimatch": "~3.0.4",
-        "nopt": "~3.0.6"
+        "mkdirp": "~1.0.4",
+        "nopt": "~3.0.6",
+        "rimraf": "~3.0.2"
       },
       "dependencies": {
         "glob": {
@@ -14528,6 +14458,21 @@
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
+          }
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
           }
         },
         "v8flags": {
@@ -15144,10 +15089,12 @@
       }
     },
     "iconv-lite": {
-      "version": "0.6.3",
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "ieee754": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "eslint-plugin-compat": "^3.13.0",
     "eslint-plugin-es5": "^1.4.1",
     "fs-extra": "^8.1.0",
-    "grunt": "^1.0.4",
+    "grunt": "1.5.3",
     "grunt-babel": "^5.0.0",
     "grunt-cli": "^1",
     "grunt-contrib-clean": "^1",


### PR DESCRIPTION
We have to pin Grunt to 1.5.3, since this
is the latest version to support Node 10,
which is needed for the release process.
