### PR TITLE
[4.x] Fix browser tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
 
   browser:
     name: Test (Browser)
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-22.04'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@ node_modules
 lib/handlebars/compiler/parser.js
 /coverage/
 /dist/
+/test-results/
 /tests/integration/*/dist/
 /spec/tmp/*

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "handlebars": "bin/handlebars"
       },
       "devDependencies": {
-        "@playwright/test": "^1.17.1",
+        "@playwright/test": "1.44.1",
         "aws-sdk": "^2.1.49",
         "babel-loader": "^5.0.0",
         "babel-runtime": "^5.1.10",
@@ -279,17 +279,18 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.58.2",
+      "version": "1.44.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.44.1.tgz",
+      "integrity": "sha512-1hZ4TNvD5z9VuhNJ/walIjvMVvYkZKf71axoF/uiAqpntQJXpG64dlXhoDXE3OczPuTuvjf/M5KWFg5VAVUS3Q==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.58.2"
+        "playwright": "1.44.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=16"
       }
     },
     "node_modules/@samverschueren/stream-to-observable": {
@@ -1033,6 +1034,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "node_modules/bluebird": {
       "version": "2.11.0",
       "dev": true,
@@ -1476,6 +1487,25 @@
       },
       "optionalDependencies": {
         "fsevents": "^1.0.0"
+      }
+    },
+    "node_modules/chokidar/node_modules/fsevents": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+      "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "deprecated": "Upgrade to fsevents v2 to mitigate potential security issues",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "nan": "^2.12.1"
+      },
+      "engines": {
+        "node": ">= 4.0"
       }
     },
     "node_modules/ci-info": {
@@ -3554,6 +3584,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "node_modules/filename-regex": {
       "version": "2.0.1",
       "dev": true,
@@ -3912,6 +3949,20 @@
       "version": "1.0.0",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -7364,6 +7415,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/nan": {
+      "version": "2.26.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
+      "integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
+      "dev": true,
+      "optional": true
+    },
     "node_modules/nanomatch": {
       "version": "1.2.13",
       "dev": true,
@@ -8360,31 +8418,33 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.58.2",
+      "version": "1.44.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.1.tgz",
+      "integrity": "sha512-qr/0UJ5CFAtloI3avF95Y0L1xQo6r3LQArLIg/z/PoGJ6xa+EwzrwO5lpNr/09STxdHuUoP2mvuELJS+hLdtgg==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.2"
+        "playwright-core": "1.44.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=16"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.2",
+      "version": "1.44.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.1.tgz",
+      "integrity": "sha512-wh0JWtYTrhv1+OSsLPgFzGzt67Y7BE/ZS3jEqgGBlp2ppp1ZDj8c+9IARNW4dwf1poq5MgHreEM2KV/GuR4cFA==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=16"
       }
     },
     "node_modules/please-upgrade-node": {
@@ -11794,10 +11854,12 @@
       }
     },
     "@playwright/test": {
-      "version": "1.58.2",
+      "version": "1.44.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.44.1.tgz",
+      "integrity": "sha512-1hZ4TNvD5z9VuhNJ/walIjvMVvYkZKf71axoF/uiAqpntQJXpG64dlXhoDXE3OczPuTuvjf/M5KWFg5VAVUS3Q==",
       "dev": true,
       "requires": {
-        "playwright": "1.58.2"
+        "playwright": "1.44.1"
       }
     },
     "@samverschueren/stream-to-observable": {
@@ -12310,6 +12372,16 @@
       "version": "1.13.1",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bluebird": {
       "version": "2.11.0",
       "dev": true
@@ -12605,6 +12677,19 @@
         "is-glob": "^2.0.0",
         "path-is-absolute": "^1.0.0",
         "readdirp": "^2.0.0"
+      },
+      "dependencies": {
+        "fsevents": {
+          "version": "1.2.13",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+          "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
+        }
       }
     },
     "ci-info": {
@@ -13955,6 +14040,13 @@
       "version": "0.1.1",
       "dev": true
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "filename-regex": {
       "version": "2.0.1",
       "dev": true
@@ -14192,6 +14284,13 @@
     "fs.realpath": {
       "version": "1.0.0",
       "dev": true
+    },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
     },
     "function-bind": {
       "version": "1.1.2",
@@ -16440,6 +16539,13 @@
       "version": "0.0.8",
       "dev": true
     },
+    "nan": {
+      "version": "2.26.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
+      "integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
+      "dev": true,
+      "optional": true
+    },
     "nanomatch": {
       "version": "1.2.13",
       "dev": true,
@@ -17113,15 +17219,19 @@
       }
     },
     "playwright": {
-      "version": "1.58.2",
+      "version": "1.44.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.1.tgz",
+      "integrity": "sha512-qr/0UJ5CFAtloI3avF95Y0L1xQo6r3LQArLIg/z/PoGJ6xa+EwzrwO5lpNr/09STxdHuUoP2mvuELJS+hLdtgg==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2",
-        "playwright-core": "1.58.2"
+        "playwright-core": "1.44.1"
       }
     },
     "playwright-core": {
-      "version": "1.58.2",
+      "version": "1.44.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.1.tgz",
+      "integrity": "sha512-wh0JWtYTrhv1+OSsLPgFzGzt67Y7BE/ZS3jEqgGBlp2ppp1ZDj8c+9IARNW4dwf1poq5MgHreEM2KV/GuR4cFA==",
       "dev": true
     },
     "please-upgrade-node": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "uglify-js": "^3.1.4"
   },
   "devDependencies": {
-    "@playwright/test": "^1.17.1",
+    "@playwright/test": "1.44.1",
     "aws-sdk": "^2.1.49",
     "babel-loader": "^5.0.0",
     "babel-runtime": "^5.1.10",

--- a/tests/browser/README.md
+++ b/tests/browser/README.md
@@ -9,6 +9,5 @@ Execute the following commands in the project root:
 ```bash
 npm install
 npx grunt prepare
-docker pull mcr.microsoft.com/playwright:focal
-docker run -it --rm --volume $(pwd):/srv/app --workdir /srv/app --ipc=host mcr.microsoft.com/playwright:focal npm run test:browser
+docker run -it --rm --volume $(pwd):/srv/app --workdir /srv/app --ipc=host mcr.microsoft.com/playwright:v1.44.1-jammy npm run test:browser
 ```

--- a/tests/browser/playwright.config.js
+++ b/tests/browser/playwright.config.js
@@ -2,6 +2,7 @@ const { devices } = require('@playwright/test');
 
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
 const config = {
+  testMatch: ['spec.js'],
   projects: [
     {
       name: 'chromium',

--- a/tests/browser/spec.js
+++ b/tests/browser/spec.js
@@ -7,27 +7,27 @@ async function waitForMochaAndAssertResult(page) {
   expect(mochaResults.failures).toBe(0);
 }
 
-test('Spec handlebars.js', async ({ page, baseURL }) => {
-  await page.goto(`${baseURL}/spec/?headless=true`);
+test('Spec handlebars.js', async ({ page }) => {
+  await page.goto(`/spec/?headless=true`);
   await waitForMochaAndAssertResult(page);
 });
 
-test('Spec handlebars.amd.js (AMD)', async ({ page, baseURL }) => {
-  await page.goto(`${baseURL}/spec/amd.html?headless=true`);
+test('Spec handlebars.amd.js (AMD)', async ({ page }) => {
+  await page.goto(`/spec/amd.html?headless=true`);
   await waitForMochaAndAssertResult(page);
 });
 
-test('Spec handlebars.runtime.amd.js (AMD)', async ({ page, baseURL }) => {
-  await page.goto(`${baseURL}/spec/amd-runtime.html?headless=true`);
+test('Spec handlebars.runtime.amd.js (AMD)', async ({ page }) => {
+  await page.goto(`/spec/amd-runtime.html?headless=true`);
   await waitForMochaAndAssertResult(page);
 });
 
-test('Spec handlebars.js (UMD)', async ({ page, baseURL }) => {
-  await page.goto(`${baseURL}/spec/umd.html?headless=true`);
+test('Spec handlebars.js (UMD)', async ({ page }) => {
+  await page.goto(`/spec/umd.html?headless=true`);
   await waitForMochaAndAssertResult(page);
 });
 
-test('Spec handlebars.runtime.js (UMD)', async ({ page, baseURL }) => {
-  await page.goto(`${baseURL}/spec/umd-runtime.html?headless=true`);
+test('Spec handlebars.runtime.js (UMD)', async ({ page }) => {
+  await page.goto(`/spec/umd-runtime.html?headless=true`);
   await waitForMochaAndAssertResult(page);
 });


### PR DESCRIPTION
Pinned the browser tests to the latest Playwright version that still works with Node 16. 

We need Node 16 for a successful build.