### PR TITLE
fix: prevent proto-access bypass via Symbol.toStringTag and escape bypass via toHTML duck-typing

### DIFF
--- a/lib/handlebars/utils.js
+++ b/lib/handlebars/utils.js
@@ -1,3 +1,5 @@
+import SafeString from './safe-string';
+
 const escape = {
   '&': '&amp;',
   '<': '&lt;',
@@ -35,18 +37,13 @@ export function isFunction(value) {
   return typeof value === 'function';
 }
 
-function testTag(name) {
-  const tag = '[object ' + name + ']';
-  return function (value) {
-    return value && typeof value === 'object'
-      ? toString.call(value) === tag
-      : false;
-  };
-}
-
 export const isArray = Array.isArray;
-export const isMap = testTag('Map');
-export const isSet = testTag('Set');
+export function isMap(value) {
+  return value instanceof Map;
+}
+export function isSet(value) {
+  return value instanceof Set;
+}
 
 // Older IE versions do not directly support indexOf so we must implement our own, sadly.
 export function indexOf(array, value) {
@@ -61,7 +58,7 @@ export function indexOf(array, value) {
 export function escapeExpression(string) {
   if (typeof string !== 'string') {
     // don't escape SafeStrings, since they're already safe
-    if (string && string.toHTML) {
+    if (string instanceof SafeString) {
       return string.toHTML();
     } else if (string == null) {
       return '';

--- a/spec/security.js
+++ b/spec/security.js
@@ -426,6 +426,52 @@ describe('security issues', function () {
     });
   });
 
+  describe('GH-2146: Proto-access control bypass via Map Symbol.toStringTag spoofing', function () {
+    it('should not treat objects with spoofed Symbol.toStringTag as Maps', function () {
+      var maliciousObj = {
+        get: function (key) {
+          return 'spoofed-' + key;
+        },
+      };
+      Object.defineProperty(maliciousObj, Symbol.toStringTag, {
+        value: 'Map',
+      });
+
+      // The spoofed object should NOT be treated as a Map,
+      // so proto-access controls should still apply
+      expectTemplate('{{constructor}}').withInput(maliciousObj).toCompileTo('');
+    });
+
+    it('should still treat real Maps correctly', function () {
+      var realMap = new Map();
+      realMap.set('key', 'value');
+
+      expectTemplate('{{key}}').withInput(realMap).toCompileTo('value');
+    });
+  });
+
+  describe('GH-2146: HTML escape bypass via toHTML duck-typing', function () {
+    it('should not call toHTML on non-SafeString objects', function () {
+      var maliciousObj = {
+        toHTML: function () {
+          return '<script>alert("xss")</script>';
+        },
+      };
+
+      // escapeExpression should NOT call toHTML on plain objects
+      var result = Handlebars.Utils.escapeExpression(maliciousObj);
+      expect(result).not.toBe('<script>alert("xss")</script>');
+      // It should coerce to string and escape
+      expect(result).not.toContain('<script>');
+    });
+
+    it('should still allow SafeString through escapeExpression', function () {
+      var safe = new Handlebars.SafeString('<b>safe</b>');
+      var result = Handlebars.Utils.escapeExpression(safe);
+      expect(result).toBe('<b>safe</b>');
+    });
+  });
+
   describe('escapes template variables', function () {
     it('in compat mode', function () {
       expectTemplate("{{'a\\b'}}")

--- a/spec/utils.js
+++ b/spec/utils.js
@@ -28,12 +28,15 @@ describe('utils', function () {
       var string = new Handlebars.SafeString('foo<&"\'>');
       expect(Handlebars.Utils.escapeExpression(string)).toBe('foo<&"\'>');
 
+      // Plain objects with toHTML should no longer bypass escaping (GH-2146)
+      // They are coerced to string like any other non-SafeString object
       var obj = {
         toHTML: function () {
           return 'foo<&"\'>';
         },
       };
-      expect(Handlebars.Utils.escapeExpression(obj)).toBe('foo<&"\'>');
+      // Object coerces to '[object Object]' which has no special chars
+      expect(Handlebars.Utils.escapeExpression(obj)).toBe('[object Object]');
     });
     it('should handle falsy', function () {
       expect(Handlebars.Utils.escapeExpression('')).toBe('');


### PR DESCRIPTION
## Summary

Fixes two security vulnerabilities reported in #2146:

- **Finding 1 (Proto-access control bypass via Map Symbol.toStringTag spoofing):** The `isMap`/`isSet` utility functions used `Object.prototype.toString.call()` to detect Maps and Sets. An attacker could craft an object with `Symbol.toStringTag` set to `'Map'` to bypass proto-access controls (the `lookupProperty` function treats Maps specially by using `.get()` instead of property access, which skips prototype chain security checks). Fixed by replacing with `instanceof Map`/`instanceof Set` checks, which cannot be spoofed.

- **Finding 2 (HTML escape bypass via toHTML duck-typing):** The `escapeExpression` function checked for a `toHTML` method on any object to bypass HTML escaping (intended only for `SafeString` instances). An attacker could create any object with a `toHTML()` method returning malicious HTML to bypass escaping. Fixed by using `instanceof SafeString` instead of duck-typing.

## Changes

- `lib/handlebars/utils.js`: Import `SafeString`, replace `testTag`-based `isMap`/`isSet` with `instanceof` checks, replace `toHTML` duck-type check with `instanceof SafeString`
- `spec/security.js`: Add tests for both vulnerabilities (Symbol.toStringTag spoofing and toHTML bypass)
- `spec/utils.js`: Update existing test to reflect that plain objects with `toHTML` no longer bypass escaping

## Test plan

- [x] All existing tests pass (only pre-existing failures in git utility tests and missing mustache submodule)
- [x] New test: objects with spoofed `Symbol.toStringTag = 'Map'` are not treated as Maps
- [x] New test: real Maps still work correctly
- [x] New test: objects with `toHTML` method do not bypass HTML escaping
- [x] New test: `SafeString` instances still bypass escaping as intended
- [x] Linting passes (`npm run lint`)

Closes #2146